### PR TITLE
Add --force-artwork flag to sync command

### DIFF
--- a/.changeset/force-artwork-flag.md
+++ b/.changeset/force-artwork-flag.md
@@ -1,0 +1,6 @@
+---
+'podkit': patch
+'@podkit/core': patch
+---
+
+Add `--force-artwork` flag to re-extract and re-transfer artwork for all matched tracks without re-transcoding or re-transferring audio files

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -133,6 +133,7 @@ podkit sync [options]
 | `--force-transcode` | Re-transcode all lossless-source tracks regardless of bitrate match |
 | `--force-sync-tags` | Write sync tags to all matched transcoded tracks without re-transcoding |
 | `--force-metadata` | Rewrite metadata on all matched tracks without re-transcoding or re-transferring files |
+| `--force-artwork` | Re-extract and re-transfer artwork for all matched tracks |
 | `--delete` | Remove tracks from iPod that are not in the source |
 | `--eject` | Eject iPod after successful sync |
 

--- a/packages/podkit-cli/src/commands/sync.ts
+++ b/packages/podkit-cli/src/commands/sync.ts
@@ -94,6 +94,7 @@ interface SyncOptions {
   forceTranscode?: boolean;
   forceSyncTags?: boolean;
   forceMetadata?: boolean;
+  forceArtwork?: boolean;
   checkArtwork?: boolean;
   delete?: boolean;
   collection?: string;
@@ -168,6 +169,7 @@ export interface UpdateBreakdown {
   'soundcheck-update'?: number;
   'metadata-correction'?: number;
   'force-metadata'?: number;
+  'force-artwork'?: number;
 }
 
 /**
@@ -547,6 +549,7 @@ export interface MusicSyncContext {
   forceTranscode: boolean;
   forceSyncTags: boolean;
   forceMetadata: boolean;
+  forceArtwork: boolean;
   checkArtwork: boolean;
   ipod: Awaited<ReturnType<typeof import('@podkit/core').IpodDatabase.open>>;
   transcoder: ReturnType<typeof import('@podkit/core').createFFmpegTranscoder>;
@@ -586,6 +589,7 @@ export async function syncMusicCollection(ctx: MusicSyncContext): Promise<MusicS
     forceTranscode,
     forceSyncTags,
     forceMetadata,
+    forceArtwork,
     checkArtwork,
     ipod,
     transcoder,
@@ -724,6 +728,7 @@ export async function syncMusicCollection(ctx: MusicSyncContext): Promise<MusicS
     forceTranscode,
     forceSyncTags,
     forceMetadata,
+    forceArtwork,
     transcodingActive: true,
     presetBitrate: core.getPresetBitrate(effectiveQuality),
     encodingMode: effectiveEncoding,
@@ -1576,6 +1581,7 @@ export const syncCommand = new Command('sync')
     '--force-metadata',
     'rewrite metadata on all matched tracks without re-transcoding or re-transferring files'
   )
+  .option('--force-artwork', 're-extract and re-transfer artwork for all matched tracks')
   .option('--check-artwork', 'detect artwork changes by comparing content hashes')
   .option('--delete', 'remove tracks from iPod not in source')
   .option('--eject', 'eject iPod after successful sync')
@@ -1960,6 +1966,7 @@ export const syncCommand = new Command('sync')
             forceTranscode: options.forceTranscode ?? config.forceTranscode ?? false,
             forceSyncTags: options.forceSyncTags ?? config.forceSyncTags ?? false,
             forceMetadata: options.forceMetadata ?? false,
+            forceArtwork: options.forceArtwork ?? false,
             checkArtwork:
               options.checkArtwork ?? getEffectiveCheckArtwork(config.checkArtwork, deviceConfig),
             ipod,

--- a/packages/podkit-cli/src/output/formatters.ts
+++ b/packages/podkit-cli/src/output/formatters.ts
@@ -143,6 +143,8 @@ export function formatUpdateReason(reason: string): string {
       return 'Metadata correction';
     case 'force-metadata':
       return 'Metadata refresh';
+    case 'force-artwork':
+      return 'Artwork refresh';
     default:
       return reason;
   }

--- a/packages/podkit-core/src/sync/differ.test.ts
+++ b/packages/podkit-core/src/sync/differ.test.ts
@@ -2406,3 +2406,77 @@ describe('computeDiff - forceMetadata', () => {
     expect(diff.toUpdate).toHaveLength(0);
   });
 });
+
+// =============================================================================
+// Force Artwork Tests
+// =============================================================================
+
+describe('computeDiff - forceArtwork', () => {
+  it('moves all matched tracks to toUpdate with force-artwork reason', () => {
+    const collectionTracks = [
+      createCollectionTrack('Artist A', 'Song 1', 'Album 1'),
+      createCollectionTrack('Artist B', 'Song 2', 'Album 2'),
+    ];
+    const ipodTracks = [
+      createIPodTrack('Artist A', 'Song 1', 'Album 1'),
+      createIPodTrack('Artist B', 'Song 2', 'Album 2'),
+    ];
+
+    const diff = computeDiff(collectionTracks, ipodTracks, { forceArtwork: true });
+
+    expect(diff.existing).toHaveLength(0);
+    expect(diff.toUpdate).toHaveLength(2);
+    expect(diff.toUpdate[0]!.reason).toBe('force-artwork');
+    expect(diff.toUpdate[1]!.reason).toBe('force-artwork');
+  });
+
+  it('still adds new tracks when forceArtwork is true', () => {
+    const collectionTracks = [
+      createCollectionTrack('Artist A', 'Song 1', 'Album 1'),
+      createCollectionTrack('Artist B', 'New Song', 'Album 2'),
+    ];
+    const ipodTracks = [createIPodTrack('Artist A', 'Song 1', 'Album 1')];
+
+    const diff = computeDiff(collectionTracks, ipodTracks, { forceArtwork: true });
+
+    expect(diff.toAdd).toHaveLength(1);
+    expect(diff.toAdd[0]!.title).toBe('New Song');
+    expect(diff.toUpdate).toHaveLength(1);
+    expect(diff.toUpdate[0]!.reason).toBe('force-artwork');
+  });
+
+  it('still identifies removals when forceArtwork is true', () => {
+    const collectionTracks = [createCollectionTrack('Artist A', 'Song 1', 'Album 1')];
+    const ipodTracks = [
+      createIPodTrack('Artist A', 'Song 1', 'Album 1'),
+      createIPodTrack('Artist B', 'Old Song', 'Album 2'),
+    ];
+
+    const diff = computeDiff(collectionTracks, ipodTracks, { forceArtwork: true });
+
+    expect(diff.toRemove).toHaveLength(1);
+    expect(diff.toRemove[0]!.title).toBe('Old Song');
+    expect(diff.toUpdate).toHaveLength(1);
+  });
+
+  it('does not move tracks to toUpdate when forceArtwork is false', () => {
+    const collectionTracks = [createCollectionTrack('Artist', 'Song', 'Album')];
+    const ipodTracks = [createIPodTrack('Artist', 'Song', 'Album')];
+
+    const diff = computeDiff(collectionTracks, ipodTracks, { forceArtwork: false });
+
+    expect(diff.existing).toHaveLength(1);
+    expect(diff.toUpdate).toHaveLength(0);
+  });
+
+  it('has empty changes array', () => {
+    const collectionTracks = [createCollectionTrack('Artist', 'Song', 'Album')];
+    const ipodTracks = [createIPodTrack('Artist', 'Song', 'Album')];
+
+    const diff = computeDiff(collectionTracks, ipodTracks, { forceArtwork: true });
+
+    expect(diff.toUpdate).toHaveLength(1);
+    expect(diff.toUpdate[0]!.reason).toBe('force-artwork');
+    expect(diff.toUpdate[0]!.changes).toHaveLength(0);
+  });
+});

--- a/packages/podkit-core/src/sync/differ.ts
+++ b/packages/podkit-core/src/sync/differ.ts
@@ -505,6 +505,20 @@ export function computeDiff(
     existing.length = 0;
   }
 
+  // Post-processing: force-artwork moves ALL remaining existing tracks to toUpdate.
+  // This re-extracts and re-transfers artwork without re-transcoding or re-transferring audio.
+  if (options?.forceArtwork) {
+    for (const match of existing) {
+      toUpdate.push({
+        source: match.collection,
+        ipod: match.ipod,
+        reason: 'force-artwork',
+        changes: [],
+      });
+    }
+    existing.length = 0;
+  }
+
   // Find iPod tracks that weren't matched (candidates for removal)
   // This includes duplicate tracks that weren't selected from the index
   const toRemove: IPodTrack[] = [];

--- a/packages/podkit-core/src/sync/executor.ts
+++ b/packages/podkit-core/src/sync/executor.ts
@@ -1629,8 +1629,8 @@ export class DefaultSyncExecutor implements SyncExecutor {
       return { bytesTransferred: 0, track: foundTrack };
     }
 
-    // artwork-updated: skip audio file transfer, only re-extract and update artwork + sync tag
-    if (operation.reason === 'artwork-updated') {
+    // artwork-updated / force-artwork: skip audio file transfer, only re-extract and update artwork + sync tag
+    if (operation.reason === 'artwork-updated' || operation.reason === 'force-artwork') {
       if (!artworkEnabled) {
         // artwork-updated with artwork disabled is a no-op — skip silently
         return { bytesTransferred: 0, track: foundTrack };

--- a/packages/podkit-core/src/sync/planner.ts
+++ b/packages/podkit-core/src/sync/planner.ts
@@ -525,7 +525,11 @@ function planUpdateOperations(
     // replace the audio file. Route it as an upgrade operation so the executor can access
     // the source, but without a preset (no transcode/copy needed).
     // artwork-removed is similar — metadata-only, removes artwork from iPod track.
-    if (reason === 'artwork-updated' || reason === 'artwork-removed') {
+    if (
+      reason === 'artwork-updated' ||
+      reason === 'artwork-removed' ||
+      reason === 'force-artwork'
+    ) {
       operations.push({
         type: 'upgrade',
         source: updateTrack.source,
@@ -603,8 +607,8 @@ export function calculateOperationSize(operation: SyncOperation): number {
       return estimateCopySize(operation.source);
     }
     case 'upgrade': {
-      // artwork-updated only transfers artwork bytes (~200KB), not the whole track
-      if (operation.reason === 'artwork-updated') {
+      // artwork-updated / force-artwork only transfers artwork bytes (~200KB), not the whole track
+      if (operation.reason === 'artwork-updated' || operation.reason === 'force-artwork') {
         return 200 * 1024;
       }
       // artwork-removed is metadata-only (no file transfer)
@@ -649,8 +653,8 @@ function calculateOperationTime(operation: SyncOperation): number {
       return estimateTransferTime(size);
     }
     case 'upgrade': {
-      // artwork-updated is nearly instant (small artwork data, no audio transfer)
-      if (operation.reason === 'artwork-updated') {
+      // artwork-updated / force-artwork is nearly instant (small artwork data, no audio transfer)
+      if (operation.reason === 'artwork-updated' || operation.reason === 'force-artwork') {
         return 0.1;
       }
       // artwork-removed is instant (metadata-only)
@@ -755,7 +759,12 @@ export function createPlan(diff: SyncDiff, options: PlanOptions = {}): SyncPlan 
   const artworkEnabled = options.artworkEnabled ?? true;
   const effectiveUpdates = artworkEnabled
     ? diff.toUpdate
-    : diff.toUpdate.filter((u) => u.reason !== 'artwork-updated' && u.reason !== 'artwork-removed');
+    : diff.toUpdate.filter(
+        (u) =>
+          u.reason !== 'artwork-updated' &&
+          u.reason !== 'artwork-removed' &&
+          u.reason !== 'force-artwork'
+      );
 
   // Plan update/upgrade operations for metadata changes and file replacements
   const updateResult = planUpdateOperations(effectiveUpdates, config, deviceSupportsAlac);

--- a/packages/podkit-core/src/sync/types.ts
+++ b/packages/podkit-core/src/sync/types.ts
@@ -42,6 +42,7 @@ export type UpgradeReason =
   | 'artwork-added'
   | 'artwork-removed'
   | 'artwork-updated'
+  | 'force-artwork'
   | 'soundcheck-update'
   | 'metadata-correction';
 
@@ -58,6 +59,7 @@ export type UpgradeReason =
  * - artwork-added: Source has artwork, iPod does not (file replacement)
  * - artwork-removed: Source no longer has artwork but iPod does (metadata-only)
  * - artwork-updated: Source artwork hash differs from iPod sync tag hash (metadata-only)
+ * - force-artwork: Unconditionally re-transfer artwork for all matched tracks (metadata-only)
  * - soundcheck-update: Source has soundcheck value, iPod lacks or differs (metadata-only)
  * - metadata-correction: Non-matching metadata fields differ (metadata-only)
  */
@@ -339,6 +341,15 @@ export interface DiffOptions {
    * @default false
    */
   forceMetadata?: boolean;
+
+  /**
+   * When true, move ALL matched tracks to `toUpdate` with reason `'force-artwork'`.
+   * This re-extracts and re-transfers artwork for every matched track without
+   * re-transcoding or re-transferring audio files.
+   *
+   * @default false
+   */
+  forceArtwork?: boolean;
 
   /**
    * When true, indicates that lossless sources are transcoded to lossy format


### PR DESCRIPTION
## Summary

- Add `--force-artwork` sync flag that re-extracts and re-transfers artwork for all matched tracks without re-transcoding or re-transferring audio files
- Reuses the existing artwork-only upgrade path (same as `--check-artwork`'s `artwork-updated` but unconditional)
- Correctly estimates size (~200KB) and time (~0.1s) per operation instead of full audio file size
- Filtered out when `--no-artwork` is active to avoid misleading dry-run output
- Music sync only (not applicable to video)

## Test plan

- [x] Unit tests for differ: `forceArtwork` moves matched tracks to `toUpdate` with correct reason
- [x] All existing tests pass (1670 core, 749 CLI)
- [x] Typecheck passes
- [ ] Manual: `podkit sync --force-artwork --dry-run` shows matched tracks with "Artwork refresh" reason
- [ ] Manual: `podkit sync --force-artwork` re-transfers artwork on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)