### PR TITLE
ci(docs): deploy from dedicated docs-live branch

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,11 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'packages/docs-site/**'
-      - 'packages/demo/demo.gif'
+      - docs-live
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,24 @@
+name: PR Checks
+
+# General PR validation. Currently runs the docs site build whenever a PR
+# touches docs sources, so docs breakage is caught at the PR that introduced
+# it rather than at release time.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'packages/docs-site/**'
+      - 'packages/demo/demo.gif'
+
+jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    name: Build docs site
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build docs site
+        run: cd packages/docs-site && bun run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,43 @@ jobs:
             echo "Created tag $TAG"
           fi
 
-  # Step 5: Update the Homebrew formula in the tap repository (CLI releases only)
+  # Step 5: Sync docs-live branch to the release commit so the docs site deploys.
+  # docs-live is a deployment branch — only updated by this job (on release) or
+  # by manual cherry-pick (for docs-only tweaks). Pushing to docs-live triggers
+  # deploy-docs.yml.
+  #
+  # Force-with-lease is safe here: any commits on docs-live (from docs-only
+  # cherry-picks) must already exist on main, since cherry-picks always
+  # originate from main. Resetting docs-live to the release commit realigns
+  # the branch without losing content.
+  sync-docs-live:
+    needs: [changesets, release, docker-tag]
+    # Run only if every component that was supposed to release did release.
+    # always() is required because some needs may be skipped (CLI-only or
+    # Docker-only releases). For each component: if it wasn't being released,
+    # we don't care about its result; if it was, it must have succeeded.
+    if: |
+      always() &&
+      needs.changesets.outputs.should_release == 'true' &&
+      (needs.changesets.outputs.has_cli_release != 'true' || needs.release.result == 'success') &&
+      (needs.changesets.outputs.has_docker_release != 'true' || needs.docker-tag.result == 'success')
+    runs-on: ubuntu-latest
+    name: Sync docs-live to release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reset docs-live to release commit
+        run: |
+          git fetch origin docs-live
+          git push origin HEAD:docs-live --force-with-lease
+
+  # Step 6: Update the Homebrew formula in the tap repository (CLI releases only)
   update-homebrew:
     needs: [changesets, release]
     if: needs.release.result == 'success'

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -39,9 +39,24 @@ jobs:
       version: 0.0.0-verify
       push: false
 
+  # Verify the docs site builds — we don't want to merge a Version Packages PR
+  # if the post-release docs deploy would fail.
+  docs:
+    needs: check-pr
+    if: needs.check-pr.outputs.is_version_pr == 'true'
+    runs-on: ubuntu-latest
+    name: Verify Docs Build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Build docs site
+        run: cd packages/docs-site && bun run build
+
   # Summary job for branch protection rules
   release-ci-passed:
-    needs: [check-pr, build, docker]
+    needs: [check-pr, build, docker, docs]
     if: always()
     runs-on: ubuntu-latest
     name: Release CI Status
@@ -58,6 +73,10 @@ jobs:
           fi
           if [[ "${{ needs.docker.result }}" != "success" ]]; then
             echo "Docker build failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.docs.result }}" != "success" ]]; then
+            echo "Docs build failed or was cancelled"
             exit 1
           fi
           echo "All release CI checks passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,8 @@ Read [agents/releases.md](agents/releases.md) when creating changesets, reviewin
 
 Quick reference: `bunx changeset` to create a changeset. Required for user-facing changes to `podkit`, `@podkit/core`, `@podkit/libgpod-node`, `@podkit/daemon` or `@podkit/docker`.
 
+Docs site deploys from a dedicated `docs-live` branch, not from `main`. Releases sync `docs-live` automatically; docs-only updates between releases require a cherry-pick from `main` to `docs-live`. See the "Docs Site Deployment" section in [agents/releases.md](agents/releases.md).
+
 ## Config Migrations
 
 Read [agents/config-migrations.md](agents/config-migrations.md) when making breaking changes to the config file format.

--- a/agents/releases.md
+++ b/agents/releases.md
@@ -56,6 +56,44 @@ bunx changeset
 6. Homebrew formula is auto-updated with new version and checksums
 7. Users get the update via `brew upgrade podkit` or `docker pull ghcr.io/jvgomg/podkit:latest`
 
+## Docs Site Deployment
+
+The docs site (`packages/docs-site`, published to https://jvgomg.github.io/podkit) deploys from a dedicated `docs-live` branch — **not** from `main`. This decouples docs publishing from code merges so unreleased work on `main` cannot accidentally appear on the public site.
+
+### How it works
+
+- `deploy-docs.yml` triggers on push to `docs-live` (or manually via `workflow_dispatch`).
+- `docs-live` is updated automatically by `release.yml`'s `sync-docs-live` job at the end of every successful release. The job force-pushes `docs-live` to the release commit.
+- Force-with-lease is safe because any commits on `docs-live` (from docs-only cherry-picks) must already exist on `main` — they originated there.
+- `verify-release.yml` and `pr-checks.yml` both run a docs build to catch breakage before it reaches `docs-live`.
+
+### Normal flow (release-coupled docs)
+
+You don't need to do anything — when the Version Packages PR merges and `release.yml` runs, `docs-live` is updated automatically and the docs site deploys with the release.
+
+### Docs-only deploy (between releases)
+
+When you want to publish a docs-only change without releasing the rest of `main`:
+
+1. Make the docs change as a normal PR against `main` (so it lives in canonical history and gets reviewed)
+2. After it merges, cherry-pick the merge commit onto `docs-live`:
+   ```bash
+   git checkout docs-live && git pull
+   git cherry-pick <commit-sha-from-main>
+   git push origin docs-live
+   ```
+3. The push triggers `deploy-docs.yml` and the docs site updates with **only** the cherry-picked change — unreleased work on `main` stays unpublished.
+
+Only cherry-pick from `main`. Never commit directly to `docs-live` — keeping `main` as the single source of truth is what makes the force-push at release time safe.
+
+### Manual / emergency deploy
+
+Trigger `deploy-docs.yml` from the GitHub Actions UI via `Run workflow`. This deploys whatever is currently on `docs-live`.
+
+### GitHub Pages environment
+
+The `github-pages` environment in repo settings restricts which branches can deploy. It must allow `docs-live` (not `main`). If a deploy fails with a permissions error, check Settings → Environments → github-pages → Deployment branches.
+
 ## Reviewing and Improving a Release PR
 
 Before merging a Version Packages PR, add a hand-written release summary above the auto-generated changelog. This makes the release accessible to users who follow the project. The audience is primarily CLI end users, but they're also interested in the technical side of how the tool is built.


### PR DESCRIPTION
## Summary

Decouples docs site publishing from `main` so unreleased work cannot appear on the public site between releases.

The docs site now deploys from a dedicated `docs-live` branch instead of `main`. The release flow updates `docs-live` automatically; docs-only updates between releases require an explicit cherry-pick from `main` to `docs-live`.

## Changes

- **`deploy-docs.yml`** — trigger is now `push: docs-live` (plus `workflow_dispatch` for manual deploys)
- **`release.yml`** — new `sync-docs-live` job force-pushes `docs-live` to the release commit, but only when every component that was supposed to release actually succeeded (handles CLI-only, Docker-only, and combined releases)
- **`verify-release.yml`** — new `docs` job builds the docs site as part of release CI, so a Version Packages PR fails if docs won't build
- **`pr-checks.yml`** (new) — builds the docs site on any PR touching `docs/`, `packages/docs-site/`, or `packages/demo/demo.gif`
- **`agents/releases.md`** — new "Docs Site Deployment" section documenting the model, the cherry-pick flow, and the GitHub Pages environment requirement
- **`AGENTS.md`** — brief pointer to the new section

## Required manual step before next release

Update **Settings → Environments → github-pages → Deployment branches** to allow `docs-live`. Otherwise the deploy will fail with a permissions error.

## Test plan

- [ ] Merge this PR; verify `release.yml` on `main` runs but does nothing (no changesets)
- [ ] Update GitHub Pages environment to allow `docs-live`
- [ ] Merge `feat/mass-storage-device-support` and create the Version Packages PR; verify the new `docs` job runs in `verify-release.yml`
- [ ] Merge the Version Packages PR; verify `sync-docs-live` runs and the docs site deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)