### PR TITLE
feat(device): automated iPod device identification via SysInfoExtended

### DIFF
--- a/.changeset/sysinfo-extended-auto-identify.md
+++ b/.changeset/sysinfo-extended-auto-identify.md
@@ -1,0 +1,35 @@
+---
+"podkit": minor
+"@podkit/core": minor
+"@podkit/libgpod-node": minor
+---
+
+Automated iPod device identification via SysInfoExtended.
+
+Modern iPods (post-2006) ship without a populated `SysInfo` file after iTunes restore. Without it, libgpod treats the device as generic — artwork breaks, ALAC support is unknown, and database checksums fail on Classic 6/7G and Nano 3G+. podkit now reads SysInfoExtended directly from iPod firmware over USB during `device add`, so first-time setup works with no manual tooling.
+
+**User-visible:**
+- `podkit device add` identifies the exact model (e.g. "iPod nano 8GB Black (3rd Generation)") with no input
+- `podkit doctor` detects missing SysInfoExtended and offers `--repair sysinfo-extended`
+- `podkit sync` works correctly on first run with full capability detection
+- Hash72 (Nano 5G) and HashAB (Nano 6G) devices get clear limitation messages
+- SysInfoExtended write is gated on user confirmation during `device add`
+
+**Core (`@podkit/core`):**
+- Unified iPod model registry — single table, both `0x120x`/`0x126x` USB ID ranges, 190+ serial-suffix → model mappings, checksum-type classification per generation
+- `ensureSysInfoExtended()` orchestrator: check existing → USB read → validate XML → write
+- USB discovery now exposes `serialNumber`, `busNumber`, `deviceAddress`; `resolveUsbDeviceFromPath()` on macOS + Linux
+- Readiness pipeline: checksum-aware severity (hash58+ devices fail without SysInfoExtended; pre-checksum devices warn)
+- `READINESS_RULES` declarative array replaces ad-hoc `determineLevel()` logic
+- New `sysinfo-extended` diagnostic check
+- Recognizes `P` / `F` model prefixes in SysInfo
+
+**libgpod-node (`@podkit/libgpod-node`):**
+- `readSysInfoExtendedFromUsb()` N-API binding, resolved via `dlsym` at runtime so it loads gracefully on systems where libgpod lacks the symbol
+- Prebuild patches upstream libgpod 0.8.3 to move `itdb_usb.c` from `tools/` into the library; libusb 1.0.27 built from source on all 6 platforms
+- `--whole-archive` / `-force_load` linker flags preserve the dlsym symbol in the `.node` binary
+
+**CLI (`podkit`):**
+- `device add` attempts SysInfoExtended read after mount, before DB init; enriches model name in summary
+- `doctor` adds suggested-actions section, drops destructive sysinfo guidance
+- `device scan` and `doctor` show clearer SysInfo readout

--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.prebuild-cache.outputs.cache-hit != 'true' && matrix.platform == 'darwin' && steps.static-cache.outputs.cache-hit != 'true'
         run: |
           brew install --quiet libplist gdk-pixbuf intltool autoconf automake libtool \
-            gtk-doc pkg-config gettext libpng jpeg-turbo libtiff meson ninja 2>/dev/null
+            gtk-doc pkg-config gettext libpng jpeg-turbo libtiff meson ninja libusb 2>/dev/null
           sudo cpan -T XML::Parser
 
       - name: Build static dependencies
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install macOS prebuild deps
         if: steps.prebuild-cache.outputs.cache-hit != 'true' && steps.static-cache.outputs.cache-hit == 'true'
-        run: brew install --quiet libplist gdk-pixbuf pkg-config gettext libpng jpeg-turbo libtiff 2>/dev/null
+        run: brew install --quiet libplist gdk-pixbuf pkg-config gettext libpng jpeg-turbo libtiff libusb 2>/dev/null
 
       - uses: actions/setup-node@v4
         if: steps.prebuild-cache.outputs.cache-hit != 'true'
@@ -96,7 +96,7 @@ jobs:
           echo "Dynamic dependencies:"
           PREBUILD=$(find prebuilds -name "*.node" | head -1)
           otool -L "$PREBUILD"
-          if otool -L "$PREBUILD" | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf'; then
+          if otool -L "$PREBUILD" | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"
             exit 1
           fi
@@ -135,7 +135,7 @@ jobs:
         run: |
           echo "Dynamic dependencies:"
           otool -L packages/podkit-cli/bin/podkit
-          if otool -L packages/podkit-cli/bin/podkit | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf'; then
+          if otool -L packages/podkit-cli/bin/podkit | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"
             exit 1
           fi
@@ -231,7 +231,7 @@ jobs:
             zlib-dev zlib-static \
             gettext-static gettext-dev \
             intltool autoconf automake libtool gtk-doc \
-            perl-xml-parser linux-headers
+            perl-xml-parser linux-headers libusb-dev
 
       - name: Build static dependencies
         if: steps.prebuild-cache.outputs.cache-hit != 'true' && steps.static-cache.outputs.cache-hit != 'true'
@@ -281,7 +281,7 @@ jobs:
           echo "Dynamic dependencies:"
           PREBUILD=$(find prebuilds -name "*.node" | head -1)
           ldd "$PREBUILD" || true
-          if ldd "$PREBUILD" 2>/dev/null | grep -E 'libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff'; then
+          if ldd "$PREBUILD" 2>/dev/null | grep -E 'libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"
             exit 1
           fi
@@ -413,7 +413,7 @@ jobs:
                 tiff-dev \
                 zlib-dev zlib-static \
                 intltool autoconf automake libtool gtk-doc \
-                perl-xml-parser linux-headers \
+                perl-xml-parser linux-headers libusb-dev \
                 nodejs npm
 
               if [ ! -f /workspace/static-deps/lib/libgpod.a ] || [ ! -f /workspace/static-deps/lib/libgdk_pixbuf-2.0.a ]; then
@@ -438,7 +438,7 @@ jobs:
               echo "==> Verifying static linking..."
               PREBUILD=$(find prebuilds -name "*.node" | head -1)
               ldd "$PREBUILD" || true
-              if ldd "$PREBUILD" 2>/dev/null | grep -E "libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff"; then
+              if ldd "$PREBUILD" 2>/dev/null | grep -E "libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff|libusb"; then
                 echo "ERROR: Found unexpected dynamic dependencies"
                 exit 1
               fi
@@ -480,7 +480,7 @@ jobs:
               packages/podkit-cli/bin/podkit --help
 
               ldd packages/podkit-cli/bin/podkit || true
-              if ldd packages/podkit-cli/bin/podkit 2>/dev/null | grep -E "libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff"; then
+              if ldd packages/podkit-cli/bin/podkit 2>/dev/null | grep -E "libgpod|libgdk_pixbuf|libglib|libgobject|libgio|libgmodule|libffi|libplist|libxml2|libsqlite|libpcre2|libpng|libjpeg|libtiff|libusb"; then
                 echo "ERROR: Found unexpected dynamic dependencies"; exit 1
               fi
 

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.platform == 'darwin' && steps.cache.outputs.cache-hit != 'true'
         run: |
           brew install --quiet libplist gdk-pixbuf intltool autoconf automake libtool \
-            gtk-doc pkg-config gettext libpng jpeg-turbo libtiff meson ninja 2>/dev/null
+            gtk-doc pkg-config gettext libpng jpeg-turbo libtiff meson ninja libusb 2>/dev/null
           sudo cpan -T XML::Parser
 
       - name: Install Linux build deps
@@ -62,7 +62,7 @@ jobs:
             build-essential pkg-config python3-pip \
             libglib2.0-dev libgdk-pixbuf-2.0-dev \
             libplist-dev libffi-dev libsqlite3-dev \
-            libpng-dev libjpeg-dev libtiff-dev libxml2-dev \
+            libpng-dev libjpeg-dev libtiff-dev libxml2-dev libusb-1.0-0-dev \
             intltool autoconf automake libtool gtk-doc-tools \
             meson ninja-build curl
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Install macOS prebuild deps
         if: matrix.platform == 'darwin' && steps.cache.outputs.cache-hit == 'true'
-        run: brew install --quiet libplist gdk-pixbuf pkg-config gettext libpng jpeg-turbo libtiff 2>/dev/null
+        run: brew install --quiet libplist gdk-pixbuf pkg-config gettext libpng jpeg-turbo libtiff libusb 2>/dev/null
 
       - name: Install Linux prebuild deps
         if: matrix.platform == 'linux' && steps.cache.outputs.cache-hit == 'true'
@@ -110,7 +110,7 @@ jobs:
           echo "Dynamic dependencies:"
           PREBUILD=$(find prebuilds -name "*.node" | head -1)
           otool -L "$PREBUILD"
-          if otool -L "$PREBUILD" | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf'; then
+          if otool -L "$PREBUILD" | tail -n +2 | grep -E 'libgpod|libglib|libgobject|libgdk_pixbuf|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"
             exit 1
           fi
@@ -122,7 +122,7 @@ jobs:
           echo "Dynamic dependencies:"
           PREBUILD=$(find prebuilds -name "*.node" | head -1)
           ldd "$PREBUILD"
-          if ldd "$PREBUILD" | grep -E 'libgpod|libgdk_pixbuf'; then
+          if ldd "$PREBUILD" | grep -E 'libgpod|libgdk_pixbuf|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"
             exit 1
           fi
@@ -171,7 +171,7 @@ jobs:
             bash build-base pkgconf python3 curl \
             glib-dev gdk-pixbuf-dev \
             libplist-dev libffi-dev sqlite-dev \
-            libpng-dev libjpeg-turbo-dev tiff-dev libxml2-dev \
+            libpng-dev libjpeg-turbo-dev tiff-dev libxml2-dev libusb-dev \
             intltool autoconf automake libtool gtk-doc \
             meson ninja perl-xml-parser linux-headers
 
@@ -211,7 +211,7 @@ jobs:
         run: |
           PREBUILD=$(find prebuilds -name "*.node" | head -1)
           ldd "$PREBUILD" || true
-          if ldd "$PREBUILD" 2>/dev/null | grep -E 'libgpod|libgdk_pixbuf'; then
+          if ldd "$PREBUILD" 2>/dev/null | grep -E 'libgpod|libgdk_pixbuf|libusb'; then
             echo "ERROR: Found unexpected dynamic dependencies"; exit 1
           fi
 
@@ -246,7 +246,7 @@ jobs:
                 bash build-base pkgconf python3 curl git \
                 glib-dev gdk-pixbuf-dev \
                 libplist-dev libffi-dev sqlite-dev \
-                libpng-dev libjpeg-turbo-dev tiff-dev libxml2-dev \
+                libpng-dev libjpeg-turbo-dev tiff-dev libxml2-dev libusb-dev \
                 intltool autoconf automake libtool gtk-doc \
                 meson ninja perl-xml-parser linux-headers \
                 nodejs npm
@@ -263,7 +263,7 @@ jobs:
 
               PREBUILD=$(find prebuilds -name "*.node" | head -1)
               ldd "$PREBUILD" || true
-              if ldd "$PREBUILD" 2>/dev/null | grep -E "libgpod|libgdk_pixbuf"; then
+              if ldd "$PREBUILD" 2>/dev/null | grep -E "libgpod|libgdk_pixbuf|libusb"; then
                 echo "ERROR: Found unexpected dynamic dependencies"; exit 1
               fi
 

--- a/agents/libgpod-node.md
+++ b/agents/libgpod-node.md
@@ -31,6 +31,26 @@ See `packages/libgpod-node/README.md` for the full list. Key deviations:
 | `clearTrackChapters()` | NULL chapterdata crashes | Create empty chapterdata |
 | `replaceTrackFile()` | `copyTrackToDevice()` no-ops if already transferred | Reset `transferred` flag, overwrite file in place |
 
+## Custom libgpod Build (SysInfoExtended USB)
+
+The prebuild CI applies a **custom patch** to libgpod that adds `itdb_read_sysinfo_extended_from_usb()` to the library. This function reads device identity XML from iPod firmware via USB vendor control transfers (libusb).
+
+**Why a patch?** The upstream libgpod 0.8.3 tarball has the `HAVE_LIBUSB` conditional in `configure.ac` and `tools/Makefile.am`, but the actual `itdb_usb.c` source file was only compiled into a standalone binary (`ipod-read-sysinfo-extended`), never into the library itself. Our patch:
+1. Copies `itdb_usb.c` into `src/` (the library)
+2. Adds `HAVE_LIBUSB` conditional to `src/Makefile.am`
+3. Adds the public declaration to `src/itdb.h`
+
+**Build implications:**
+- `build-static-deps.sh` builds libusb 1.0.27 as a static dependency
+- `get-ldflags.sh` uses `-Wl,-force_load` (macOS) / `-Wl,--whole-archive` (Linux) for `libgpod.a` — this forces all object files into the binary, including `itdb_usb.o` which is only referenced via `dlsym` at runtime
+- The N-API binding resolves the symbol at runtime via `dlsym(RTLD_DEFAULT, "itdb_read_sysinfo_extended_from_usb")` — if the symbol isn't present (e.g., system libgpod without the patch), the function gracefully returns null
+
+**Files involved:**
+- `tools/prebuild/patches/itdb_usb.c` — the C source
+- `tools/prebuild/patches/apply-sysinfo-usb.sh` — applies the patch to a fresh libgpod source tree
+- `tools/prebuild/build-static-deps.sh` — builds libusb + applies patch
+- `packages/libgpod-node/native/gpod_binding.cc` — dlsym resolution
+
 ## Investigating New Issues
 
 When encountering libgpod CRITICAL assertions or unexpected behavior:

--- a/backlog/docs/doc-029 - PRD-Automated-iPod-Device-Identification-via-SysInfoExtended.md
+++ b/backlog/docs/doc-029 - PRD-Automated-iPod-Device-Identification-via-SysInfoExtended.md
@@ -1,0 +1,226 @@
+---
+id: doc-029
+title: 'PRD: Automated iPod Device Identification via SysInfoExtended'
+type: other
+created_date: '2026-04-19 17:06'
+---
+## Problem Statement
+
+When a modern iPod (post-2006) is restored via iTunes or connected fresh, the `iPod_Control/Device/SysInfo` file is either empty (0 bytes) or absent. This file is a hard requirement for libgpod — without it, the device is treated as "generic" and critical functionality breaks:
+
+- **No artwork:** libgpod returns an empty format list for unknown devices, so album art is never written
+- **No ALAC support:** codec capabilities are unknown, so lossless files may be transcoded unnecessarily or rejected
+- **Checksum failure:** iPod Classic and Nano 3G+ require an HMAC-signed database using the device's FirewireGuid. Without it, `itdb_write()` fails or produces a database the iPod rejects (shows no music)
+- **Wrong model identification:** `podkit device add` reports the iPod as "Unknown", `podkit doctor` flags a fault, and `podkit sync` uses conservative generic defaults
+
+This affects all iPod Classic (6th/7th gen), Nano (3rd gen+), and any device that has been freshly restored — which is the most common first-time podkit user scenario.
+
+The root cause is historical: libgpod was designed around a manual workflow where users ran a separate tool (`ipod-read-sysinfo-extended`) before using the library. This tool reads device identity data directly from iPod firmware via USB vendor control transfers. The data has always been available from the device — it was just never integrated into an automated flow.
+
+## Solution
+
+podkit will automatically read SysInfoExtended from iPod firmware via USB and write it to the device filesystem as part of device setup. This eliminates all manual device identification steps and provides libgpod with the richest possible device data.
+
+The SysInfoExtended XML (read from firmware via USB vendor control transfers using libusb) contains everything needed: FirewireGuid, serial number (which maps to exact model including color and capacity via libgpod's serial→model lookup table), codec support, artwork format specifications, video capabilities, and checksum type.
+
+When SysInfoExtended is present on disk, libgpod prefers it over SysInfo for all device identification — making the traditional `ModelNumStr` in SysInfo redundant.
+
+**User experience after this change:**
+
+- `podkit device add` reads SysInfoExtended automatically during setup. User sees their exact device identified (e.g., "iPod nano 8GB Black (3rd Generation)") with no manual input
+- `podkit doctor` detects missing SysInfoExtended and tells the user to run a repair command
+- `podkit doctor --repair sysinfo-extended` reads and writes SysInfoExtended from the connected device
+- `podkit sync` works correctly on first run with full capability detection
+
+## User Stories
+
+1. As a user adding a freshly restored iPod, I want podkit to automatically identify my exact device model, so that I don't have to manually look up model numbers or configure device capabilities
+2. As a user adding a freshly restored iPod, I want podkit to automatically obtain the FirewireGuid from my device, so that database checksums are correct and my iPod accepts the synced music
+3. As a user running `podkit doctor`, I want to see a clear explanation when SysInfoExtended is missing, so that I understand why my device might not work correctly
+4. As a user running `podkit doctor --repair sysinfo-extended`, I want podkit to read the device identity from firmware and write it to disk, so that my device is fully configured without needing iTunes
+5. As a user with an iPod Classic 6th/7th gen, I want podkit to automatically handle hash58 checksum requirements, so that my iPod doesn't reject the database after sync
+6. As a user with an iPod Nano 3rd/4th gen, I want artwork to work on first sync, so that I see album art on my device without extra configuration
+7. As a user on macOS, I want device identification to work via the libusb transport, so that no additional system tools are needed
+8. As a user on Linux, I want device identification to work via the same libusb transport, so that the experience is consistent across platforms
+9. As a user who provides an explicit `--path` to `device add`, I want podkit to still identify the device via USB by correlating the mount path to USB bus info, so that the `--path` workflow isn't degraded
+10. As a user adding a device, I want to see my iPod's exact color and capacity in the device summary (e.g., "iPod Classic 160GB Black (7th Generation)"), so that I have confidence podkit understands my hardware
+11. As a user with an iPod Nano 5th gen (hash72), I want podkit to clearly tell me that initial iTunes sync is required for HashInfo bootstrapping, so that I understand the limitation rather than getting a cryptic error
+12. As a user with an iPod Nano 6th gen (hashAB), I want podkit to clearly tell me that this device requires proprietary components not available in podkit, so that I understand the limitation upfront
+13. As a developer working on podkit, I want the USB product ID table to be accurate and cover both `0x120x` and `0x126x` ID ranges, so that device scanning correctly identifies connected iPods
+14. As a developer working on podkit, I want the model lookup tables to have a single source of truth, so that model data isn't duplicated across packages
+15. As a developer, I want the libgpod-node binding for SysInfoExtended reading to be a standalone function (not requiring an open database), so that it can be called during device setup before any database exists
+16. As a developer, I want USB discovery to capture bus number, device address, and serial number, so that these are available for SysInfoExtended reading and diagnostics
+
+## Implementation Decisions
+
+### libgpod Library Modification
+
+The `read_sysinfo_extended_from_usb()` function currently lives in `tools/ipod-usb.c` and is compiled only into the standalone `ipod-read-sysinfo-extended` binary. It will be moved into the libgpod library source (`src/`) so that it becomes part of `libgpod.a` / `libgpod.dylib`. The build configuration (Makefile.am / configure.ac) will be updated to conditionally link libusb into the library when `HAVE_LIBUSB` is defined. The function will be declared in the public header so that downstream consumers (including libgpod-node) can call it directly.
+
+The GLib dependency in `ipod-usb.c` is acceptable since libgpod already depends on GLib throughout.
+
+### libgpod-node Native Binding
+
+A new standalone function (not a method on DatabaseWrapper) will be added to the native binding, following the existing pattern used by `Parse()`, `InitIpod()`, and other module-level exports. The function accepts USB bus number and device address, calls the libgpod library function, and returns the XML string or null. The binding.gyp build configuration will add `libusb-1.0` to the pkg-config dependencies.
+
+TypeScript wrapper exposes this as an async function in the binding module.
+
+### USB Discovery Enhancement
+
+The USB discovery module will be enhanced on both platforms:
+
+**macOS (`system_profiler` parsing):**
+- Capture `serial_num` field (= FirewireGuid, 16 hex chars)
+- Capture `location_id` and derive USB bus number (top byte) and device address
+- Add these to the `UsbDiscoveredDevice` / `UsbDeviceInfo` interfaces
+
+**Linux (sysfs parsing):**
+- Read `busnum` and `devnum` files from sysfs device path (already walking the tree, just not extracting these)
+- Read `serial` file from sysfs (= FirewireGuid)
+- Add to same interfaces
+
+**Path-to-USB correlation:**
+- For the `device add --path` case, USB lookup will be performed by correlating the mount path back to a USB device via platform-specific mechanisms (macOS: match `bsd_name` in system_profiler Media tree; Linux: follow `/sys/block/{dev}/device` symlink up to USB device)
+
+### USB Product ID Table Fix
+
+The current product ID lookup table is incomplete. Known gap: the `0x126x` range (confirmed by a real Nano 3G reporting `0x1262` while the table only has `0x1208`). The table will be audited against the Linux USB ID database (`usb.ids`) and direct device testing. Both ID ranges will be included with comments explaining the difference (likely related to USB configuration or firmware generation).
+
+### SysInfoExtended Orchestrator
+
+A new module in podkit-core provides the high-level orchestration:
+
+1. Accept mount point and USB device info (bus, address)
+2. Check if `SysInfoExtended` already exists on device filesystem
+3. If missing: call libgpod-node binding to read XML from firmware via USB
+4. Validate the returned XML (well-formed, contains expected keys like FireWireGUID and SerialNumber)
+5. Write XML to `iPod_Control/Device/SysInfoExtended`
+6. Return result indicating success, what was found, or why it failed
+
+This is the deep module — simple interface, encapsulates USB transfer details, XML validation, filesystem operations, and error handling.
+
+### Readiness Pipeline Update
+
+The SysInfo readiness stage will be updated to account for SysInfoExtended:
+
+- **Pass:** SysInfoExtended present with valid content, OR SysInfo present with valid ModelNumStr
+- **Warn:** SysInfo present but SysInfoExtended missing (device works but may lack full capability data)
+- **Fail:** Both missing → suggest `podkit doctor --repair sysinfo-extended`
+
+A new repairable check ID (`sysinfo-extended`) will be added to the diagnostics framework, following the existing pattern for artwork-rebuild and orphan-files checks.
+
+### Initialization Capability Mapping
+
+A clear data structure will map iPod generations to their initialization requirements:
+
+- **No checksum:** 1st–4th gen, Photo, Mini, Shuffle, Nano 1–2, Video 5/5.5 → SysInfoExtended optional (nice to have for capabilities)
+- **Hash58:** Classic 6th/7th, Nano 3rd/4th → SysInfoExtended required (provides FirewireGuid for checksum)
+- **Hash72:** Nano 5th → SysInfoExtended required + HashInfo bootstrap from iTunes-written DB (graceful failure with clear message)
+- **HashAB:** Nano 6th, Touch 4th → requires proprietary `libhashab.so` (graceful failure with clear message)
+
+This mapping informs both the readiness pipeline (how severe is a missing SysInfoExtended?) and the CLI messaging (what does the user need to do?).
+
+### CLI Integration
+
+**`device add`:**
+- After mounting and before database init/open, check for SysInfoExtended
+- If missing: automatically attempt USB read and write
+- Show result in device summary (exact model name from serial→model lookup)
+- If USB read fails: warn but continue (device may still work for older models that don't need checksums)
+
+**`doctor`:**
+- SysInfoExtended check integrated into readiness display
+- Missing SysInfoExtended on a device that requires it (hash58+) → fail with repair suggestion
+- `doctor --repair sysinfo-extended` triggers the orchestrator
+
+### Refactoring Opportunities
+
+**Model table consolidation:**
+The codebase currently has three overlapping model data sources: `ipod-models.ts` in podkit-core (USB product ID → name, plus ModelNumStr → name), `models.ts` in ipod-db (195-entry table with generation, capacity, color, musicDirs), and libgpod's internal `ipod_info_table`. Since ipod-db is not yet integrated as a dependency, the relevant model data (USB product ID mapping, serial suffix → model mapping) will be copied into podkit-core with clear comments noting the duplication and referencing ipod-db as the future single source of truth. The existing separate lookup tables in `ipod-models.ts` should be unified into a single model registry with multiple access patterns (by USB ID, by ModelNumStr, by serial suffix).
+
+**USB discovery refactoring:**
+The macOS USB tree traversal code has duplicated recursive walks. These should be consolidated into a generic tree search with predicate/collector callbacks. The `UsbDiscoveredDevice` interface should be extended to carry bus/address/serial as first-class fields rather than bolting them on later.
+
+**Readiness pipeline cleanup:**
+The `determineLevel()` function is a growing switch/case that will become harder to maintain. While a full stage registry pattern may be over-engineering for the current stage count, the function should be restructured for clarity — potentially using an ordered rules list rather than nested conditionals.
+
+**Platform device manager alignment:**
+Linux and macOS device managers have diverged in capability (Linux lacks `getSiblingVolumes()`, macOS has complex dual-LUN handling). Shared interfaces should be tightened so that both platforms provide the same USB info structure, making the SysInfoExtended orchestrator platform-agnostic.
+
+## Testing Decisions
+
+Tests should verify external behavior through the module's public interface. No mocking of internal functions — test the contract, not the wiring.
+
+### What makes a good test in this context
+
+- Tests that feed realistic input (real system_profiler JSON, real sysfs file structures, real SysInfoExtended XML) and verify correct output
+- Tests that verify error paths (USB read failure, malformed XML, missing files, permission errors)
+- Tests that use the existing gpod-testing utilities for iPod filesystem fixtures
+- Integration tests that verify the full chain where possible (USB info → orchestrator → file written → libgpod reads it correctly)
+
+### Modules to test
+
+**USB discovery parsing (unit tests):**
+- macOS: parse system_profiler JSON fixtures with `serial_num`, `location_id`, various product IDs
+- Linux: parse sysfs directory fixtures with `busnum`, `devnum`, `serial`, `idVendor`, `idProduct`
+- Product ID table: verify all known IDs resolve, verify both `0x120x` and `0x126x` ranges
+- Path-to-USB correlation: given a mount path and USB tree, verify correct device is matched
+- Prior art: existing usb-discovery tests if any, otherwise readiness.test.ts pattern
+
+**SysInfoExtended orchestrator (unit tests):**
+- Given valid XML string and mount point → writes file to correct location
+- Given mount point where SysInfoExtended already exists → skips (no overwrite)
+- Given null/empty XML → returns appropriate error
+- Given malformed XML (missing FireWireGUID) → returns validation error
+- XML parsing: extract FirewireGuid, SerialNumber, FamilyID, DBVersion from real XML fixtures
+- Prior art: readiness.test.ts (similar filesystem-based checks with temp directories)
+
+**Model registry (unit tests):**
+- Serial suffix lookup: verify known suffixes map to correct models (e.g., "YXX" → nano 3G black 8GB)
+- USB product ID lookup: verify both ID ranges return correct generation
+- Unknown/missing values: verify graceful fallback behavior
+- Prior art: existing lookupIpodModel / lookupIpodModelByNumber tests if any
+
+**Readiness pipeline SysInfo stage (unit tests):**
+- SysInfoExtended present → pass
+- SysInfo present but SysInfoExtended missing → warn
+- Both missing → fail with correct repair suggestion
+- Prior art: readiness.test.ts (comprehensive existing test suite for all stages)
+
+**libgpod-node binding (integration tests):**
+- `readSysInfoExtendedFromUsb()` with invalid bus/address → returns null (no crash)
+- Cannot test real USB transfer without hardware — rely on the orchestrator and CLI-level E2E tests
+- Prior art: database.integration.test.ts
+
+**CLI E2E (integration tests with dummy iPod):**
+- `device add` on an iPod fixture without SysInfoExtended → verify it attempts USB read
+- `doctor` on an iPod fixture without SysInfoExtended → verify correct diagnostic output and repair suggestion
+- Prior art: e2e-tests package (dummy iPod test infrastructure)
+
+## Out of Scope
+
+- **ipod-db as a runtime dependency of podkit-core:** Model data will be copied, not imported. Full ipod-db integration is tracked separately (m-8)
+- **User-interactive model picker UX:** SysInfoExtended provides exact model via serial number lookup. No fallback picker if USB read fails — fail gracefully instead
+- **SysInfo file writing:** SysInfoExtended supersedes SysInfo for libgpod. If both are needed for edge cases, libgpod handles that internally when it reads SysInfoExtended
+- **SCSI/sgutils transport:** Linux sgutils path is a bonus if the build has sgutils, but libusb is the primary and cross-platform path. No work to add sgutils support
+- **Hash72/HashAB support:** Nano 5G (hash72) and Nano 6G/Touch 4G (hashAB) have additional requirements beyond SysInfoExtended. This PRD covers detecting and messaging these limitations, not solving them
+- **Automatic `ipod-read-sysinfo-extended` invocation via shell:** The solution integrates at the library level, not by shelling out to the existing binary
+- **SysInfoExtended parsing in podkit-core:** libgpod handles parsing internally. podkit-core only needs to write the raw XML to disk and optionally extract a few fields for display purposes
+
+## Further Notes
+
+### Key technical reference
+
+- **USB vendor control transfer:** Request type `LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE`, request `0x40`, value `0x02`, iterating index from 0 until short read. This is Apple's proprietary protocol for reading device identity XML
+- **Serial → model lookup:** Last 3 characters of the serial number from SysInfoExtended map to a specific model via libgpod's `serial_to_model_mapping` table (e.g., "YXX" → model "B261" → "iPod nano 8GB Black (3rd Generation)")
+- **libgpod preference order:** `itdb_device_get_ipod_info()` tries SysInfoExtended first (via serial), falls back to SysInfo ModelNumStr
+- **FirewireGuid equivalence:** The `serial_num` from USB descriptors (`system_profiler`, sysfs) is the same value as `FireWireGUID` in SysInfoExtended and `FirewireGuid` in SysInfo — all represent the device's 64-bit hardware identifier
+- **DBVersion field in SysInfoExtended** determines checksum type: 3 = hash58, 4 = hash72, 5 = hashAB. This is more reliable than generation-based lookup
+
+### Verified on real hardware
+
+The libusb USB vendor transfer approach was tested on a real iPod Nano 3rd gen (product ID `0x1262`, serial `5U8280FNYXX`) running firmware 1.1.3. The existing `ipod-read-sysinfo-extended` tool (compiled as part of the libgpod macOS build with `HAVE_LIBUSB=1`) successfully read 12KB of SysInfoExtended XML containing full device identity, codec support, artwork formats, and video capabilities. The XML was written to `iPod_Control/Device/SysInfoExtended` on the device filesystem.
+
+### ADR consideration
+
+This work involves a significant architectural decision (how podkit identifies iPod devices) that should be captured in an ADR. The ADR should document: the discovery that SysInfo is not firmware-created on modern iPods, the decision to use SysInfoExtended via libusb as the primary identification method, and the decision to modify the libgpod library build to expose the USB transfer function.

--- a/backlog/tasks/task-279 - Automated-iPod-Device-Identification-via-SysInfoExtended.md
+++ b/backlog/tasks/task-279 - Automated-iPod-Device-Identification-via-SysInfoExtended.md
@@ -1,0 +1,36 @@
+---
+id: TASK-279
+title: Automated iPod Device Identification via SysInfoExtended
+status: To Do
+assignee: []
+created_date: '2026-04-19 17:10'
+labels:
+  - device
+  - libgpod
+  - usb
+dependencies: []
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Parent task for automated iPod device identification. Modern iPods (post-2006) don't create a populated SysInfo file after restore, causing libgpod to treat the device as generic — no artwork, no ALAC, broken checksums. This work integrates SysInfoExtended reading (via USB vendor control transfers using libusb) into podkit's device setup flow, eliminating all manual device identification steps.
+
+See PRD: doc-029 for full design, user stories, and implementation decisions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 podkit device add on a freshly restored iPod automatically reads SysInfoExtended from firmware and writes it to iPod_Control/Device/SysInfoExtended
+- [ ] #2 podkit doctor detects missing SysInfoExtended and suggests a repair command
+- [ ] #3 podkit doctor --repair sysinfo-extended reads and writes SysInfoExtended from the connected device
+- [ ] #4 Device is identified by exact model including color and capacity (e.g., iPod nano 8GB Black 3rd Generation)
+- [ ] #5 Works on both macOS and Linux
+- [ ] #6 USB product ID table covers both 0x120x and 0x126x ranges
+- [ ] #7 iPod models requiring hash72/hashAB show clear limitation messages
+<!-- AC:END -->

--- a/backlog/tasks/task-279 - Automated-iPod-Device-Identification-via-SysInfoExtended.md
+++ b/backlog/tasks/task-279 - Automated-iPod-Device-Identification-via-SysInfoExtended.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-279
 title: Automated iPod Device Identification via SysInfoExtended
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 17:10'
+updated_date: '2026-04-29 12:37'
 labels:
   - device
   - libgpod
@@ -26,11 +27,17 @@ See PRD: doc-029 for full design, user stories, and implementation decisions.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 podkit device add on a freshly restored iPod automatically reads SysInfoExtended from firmware and writes it to iPod_Control/Device/SysInfoExtended
-- [ ] #2 podkit doctor detects missing SysInfoExtended and suggests a repair command
-- [ ] #3 podkit doctor --repair sysinfo-extended reads and writes SysInfoExtended from the connected device
-- [ ] #4 Device is identified by exact model including color and capacity (e.g., iPod nano 8GB Black 3rd Generation)
-- [ ] #5 Works on both macOS and Linux
-- [ ] #6 USB product ID table covers both 0x120x and 0x126x ranges
-- [ ] #7 iPod models requiring hash72/hashAB show clear limitation messages
+- [x] #1 podkit device add on a freshly restored iPod automatically reads SysInfoExtended from firmware and writes it to iPod_Control/Device/SysInfoExtended
+- [x] #2 podkit doctor detects missing SysInfoExtended and suggests a repair command
+- [x] #3 podkit doctor --repair sysinfo-extended reads and writes SysInfoExtended from the connected device
+- [x] #4 Device is identified by exact model including color and capacity (e.g., iPod nano 8GB Black 3rd Generation)
+- [x] #5 Works on both macOS and Linux
+- [x] #6 USB product ID table covers both 0x120x and 0x126x ranges
+- [x] #7 iPod models requiring hash72/hashAB show clear limitation messages
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary\n\nAutomatic iPod device identification via SysInfoExtended — eliminates all manual device configuration for post-2006 iPods.\n\n### Problem\n\nModern iPods (Classic 6/7G, Nano 3G+) don't create a populated SysInfo file after restore. libgpod treats them as \"generic\" — no artwork, no ALAC support, broken database checksums. Users had to manually run a separate tool or look up model numbers.\n\n### Solution\n\npodkit now automatically reads SysInfoExtended from iPod firmware via USB vendor control transfers during `device add`, writes it to the device filesystem, and uses the rich identity data (serial → exact model with color/capacity/generation) for all downstream operations.\n\n### What shipped\n\n- **Native binding**: `readSysInfoExtendedFromUsb()` via N-API with dlsym runtime resolution\n- **USB discovery**: serial, bus number, device address on both macOS and Linux\n- **Unified model registry**: 0x120x + 0x126x USB ID ranges, 190+ serial suffix→model mappings, checksum type classification\n- **Orchestrator**: read → validate → write pipeline with dependency injection for testing\n- **Readiness pipeline**: SysInfoExtended-aware with checksum severity (hash58+ fail, others warn)\n- **Diagnostic check**: `doctor --repair sysinfo-extended` for manual repair\n- **Device add integration**: automatic, non-blocking, enriches model display\n- **CI prebuild**: libusb statically linked, itdb_usb.c patched into libgpod, force_load for dlsym\n- **Refactoring**: consolidated macOS tree traversal, declarative readiness rules, aligned platform USB info\n\n### Technical decisions\n\n- **dlsym over static linking**: gracefully unavailable on systems without libusb\n- **Regex plist parsing**: simple, sufficient for known key extraction, no XML parser dependency\n- **Model data duplication**: copied from libgpod rather than importing ipod-db (future consolidation tracked)\n- **Non-blocking device add**: USB failures warn but never block — older iPods work without SysInfoExtended"
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.01 - Move-ipod-usb.c-into-libgpod-library-and-expose-in-libgpod-node.md
+++ b/backlog/tasks/task-279.01 - Move-ipod-usb.c-into-libgpod-library-and-expose-in-libgpod-node.md
@@ -1,0 +1,69 @@
+---
+id: TASK-279.01
+title: Move ipod-usb.c into libgpod library and expose in libgpod-node
+status: Done
+assignee: []
+created_date: '2026-04-19 17:11'
+updated_date: '2026-04-19 18:01'
+labels:
+  - libgpod
+  - native
+  - usb
+dependencies: []
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+  - agents/libgpod-node.md
+parent_task_id: TASK-279
+priority: high
+ordinal: 1000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Move the `read_sysinfo_extended_from_usb()` function from libgpod's `tools/ipod-usb.c` into the library itself (`src/`) so it becomes part of `libgpod.a`/`libgpod.dylib`. Then add a thin N-API wrapper in libgpod-node exposing it as a standalone function (not on DatabaseWrapper — doesn't need an open database).
+
+**libgpod build changes:**
+- Move `ipod-usb.c` from `tools/` to `src/`
+- Update `src/Makefile.am` to include it conditionally when `HAVE_LIBUSB`
+- Declare `read_sysinfo_extended_from_usb()` in public header (`itdb.h`)
+- Update `configure.ac` to link libusb into the library (not just the tool)
+
+**libgpod-node binding:**
+- Add standalone function in `gpod_binding.cc` following the pattern of `Parse()`, `InitIpod()` etc
+- Function signature: `ReadSysInfoExtendedFromUsb(busNumber: number, deviceAddress: number): string | null`
+- Add `libusb-1.0` to pkg-config dependencies in `binding.gyp`
+- TypeScript wrapper in binding module
+
+**Key reference:**
+- `tools/libgpod-macos/build/libgpod-0.8.3/tools/ipod-usb.c` — ~85 lines, uses libusb vendor control transfers (request 0x40, value 0x02)
+- `packages/libgpod-node/native/gpod_binding.cc` — see `InitIpod()` for standalone function pattern
+- The function depends on GLib (GString, g_print) which is fine since libgpod already depends on GLib
+
+See PRD: doc-029 — "libgpod Library Modification" and "libgpod-node Native Binding" sections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 read_sysinfo_extended_from_usb() is compiled into libgpod.a and declared in itdb.h
+- [x] #2 libgpod macOS build succeeds with libusb linked into the library
+- [x] #3 libgpod-node binding exposes readSysInfoExtendedFromUsb() as a standalone module-level function
+- [x] #4 binding.gyp includes libusb-1.0 in pkg-config dependencies
+- [x] #5 Calling with invalid bus/address returns null without crashing
+- [x] #6 TypeScript types exported for the new function
+- [x] #7 Existing libgpod-node tests still pass
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Created src/itdb_usb.c from tools/ipod-usb.c — renamed function to itdb_read_sysinfo_extended_from_usb, removed g_print calls, fixed GString leak in error path. Updated Makefile.am with HAVE_LIBUSB conditional, declared in itdb.h. Rebuilt and installed libgpod. Added N-API wrapper in gpod_binding.cc with extern C linkage, argument validation, g_free after JS string copy. Updated binding.gyp with libusb-1.0. TypeScript wrapper and export added. Verified on real hardware: 14KB XML returned from iPod Nano 4G (bus=3, addr=17). Invalid address returns null without crash. 282 libgpod-node tests pass, full build clean.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Moved `read_sysinfo_extended_from_usb()` from libgpod's `tools/ipod-usb.c` into the library as `itdb_read_sysinfo_extended_from_usb()` in `src/itdb_usb.c`, declared in `itdb.h`, conditionally compiled when `HAVE_LIBUSB` is set. Rebuilt and installed libgpod with the new symbol verified in `libgpod.a`. Added N-API wrapper `ReadSysInfoExtendedFromUsb()` in `gpod_binding.cc` with TypeScript bindings exported from `@podkit/libgpod-node`. Updated `binding.gyp` to link `libusb-1.0`. All 282 existing tests pass. Verified with real iPod Nano 4G (bus=3, addr=17) returning 14297 bytes of SysInfoExtended XML, and confirmed null return for invalid bus/address without crash.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.02 - Enhance-USB-discovery-to-capture-serial-bus-number-and-device-address.md
+++ b/backlog/tasks/task-279.02 - Enhance-USB-discovery-to-capture-serial-bus-number-and-device-address.md
@@ -1,0 +1,71 @@
+---
+id: TASK-279.02
+title: 'Enhance USB discovery to capture serial, bus number, and device address'
+status: Done
+assignee: []
+created_date: '2026-04-19 17:11'
+updated_date: '2026-04-19 17:50'
+labels:
+  - device
+  - usb
+dependencies: []
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: high
+ordinal: 2000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend USB discovery on both platforms to capture the additional fields needed for SysInfoExtended reading: serial number (= FirewireGuid), USB bus number, and device address.
+
+**macOS (`system_profiler` parsing in usb-discovery.ts):**
+- Capture `serial_num` field from system_profiler JSON (16 hex char FirewireGuid, e.g., "000A27001BC8EED6")
+- Capture `location_id` and derive bus number (top byte of location_id, e.g., 0x03100000 → bus 3) and device address (the "/ 14" suffix)
+- Add fields to `UsbDiscoveredDevice` and `UsbDeviceInfo` interfaces
+
+**Linux (sysfs parsing in usb-discovery.ts):**
+- Read `busnum` and `devnum` files from sysfs device path (code already walks the sysfs tree but doesn't extract these)
+- Read `serial` file from sysfs (= FirewireGuid)
+- Add to same interfaces
+
+**Path-to-USB correlation (for `device add --path`):**
+- macOS: correlate mount path → bsd_name → system_profiler Media tree → USB device info
+- Linux: follow `/sys/block/{dev}/device` symlink up to USB device node
+- New function: given a mount path, return USB device info (bus, address, serial) or null
+
+**Verified data from real hardware (iPod Nano 3G):**
+- system_profiler reports: `"serial_num": "000A27001BC8EED6"`, `"location_id": "0x03100000 / 14"`, `"product_id": "0x1262"`
+- These map to: bus=3, address=14, FirewireGuid=000A27001BC8EED6
+
+See PRD: doc-029 — "USB Discovery Enhancement" section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 UsbDiscoveredDevice interface includes optional busNumber, deviceAddress, and serialNumber fields
+- [x] #2 macOS parser extracts serial_num, bus number, and device address from system_profiler JSON
+- [x] #3 Linux parser extracts busnum, devnum, and serial from sysfs
+- [x] #4 New function resolves mount path to USB device info on macOS (via bsd_name correlation)
+- [x] #5 New function resolves mount path to USB device info on Linux (via sysfs symlink traversal)
+- [x] #6 Unit tests with fixture JSON/sysfs data verify field extraction on both platforms
+- [x] #7 Existing USB discovery tests still pass
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended UsbDiscoveredDevice and UsbDeviceInfo with optional serialNumber, busNumber, deviceAddress. macOS parser extracts serial_num, location_id (bus/address). Linux parser reads busnum/devnum/serial from sysfs. Added resolveUsbDeviceFromPath (macOS implemented, Linux TODO). Added 0x1266 to UNSUPPORTED_IPODS. 12 new tests added.
+
+AC #5 implemented: Linux resolveUsbDeviceFromPath via /proc/mounts → sysfs block device → USB ancestor traversal. Tested with fixture temp directories mimicking sysfs structure. Runs on Lima VMs via existing run-tests.sh.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Changes\n\n### Interfaces extended\n- `UsbDiscoveredDevice` (usb-discovery.ts): added optional `serialNumber`, `busNumber`, `deviceAddress`\n- `UsbDeviceInfo` (assessment.ts): added same three optional fields\n- `SysfsUsbDevice` (usb-discovery.ts): added optional `busnum`, `devnum`, `serial`; exported the interface\n\n### macOS parser\n- `SystemProfilerItem` now includes `serial_num` and `location_id`\n- `walkItems` extracts serial number, bus number, and device address from system_profiler JSON\n- New `extractSerialNumber()` helper\n- New exported `parseLocationId()` — parses `\"0x03100000 / 14\"` into `{ busNumber: 3, deviceAddress: 14 }`\n\n### Linux parser\n- `discoverLinux()` now reads `busnum`, `devnum`, `serial` sysfs files\n- `parseSysfsUsbDevices()` passes these through to results\n\n### Path-to-USB correlation\n- New exported `resolveUsbDeviceFromPath(mountPath, options?)` function\n- macOS: correlates mount path → diskutil device node → system_profiler bsd_name → USB device info\n- Linux: TODO placeholder (returns null)\n- Exported from device index\n\n### Tests (10 new tests)\n- Serial/bus/address extraction from system_profiler data\n- Missing fields remain undefined\n- `parseLocationId` edge cases (8 tests): standard format, high bus, hex-only, empty, malformed, no-space slash\n- Linux sysfs with busnum/devnum/serial\n- Linux sysfs without optional fields\n\n### Quality gates\n- All 2290 tests pass (35 in usb-discovery.test.ts)\n- Build clean across all 12 packages
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.03 - Audit-and-fix-USB-product-ID-table.md
+++ b/backlog/tasks/task-279.03 - Audit-and-fix-USB-product-ID-table.md
@@ -1,0 +1,67 @@
+---
+id: TASK-279.03
+title: Audit and fix USB product ID table
+status: Done
+assignee: []
+created_date: '2026-04-19 17:11'
+updated_date: '2026-04-19 17:40'
+labels:
+  - device
+  - usb
+dependencies: []
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: medium
+ordinal: 3000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The USB product ID lookup table in `ipod-models.ts` is incomplete. A real iPod Nano 3G reports product ID `0x1262`, but the table only has `0x1208` for Nano 3G. The Linux USB ID database (`usb.ids` at linux-usb.org) shows a second range of IDs (`0x126x`) not present in podkit's table.
+
+**Known ID ranges:**
+- `0x120x` range: currently in podkit's table (source: community databases, may represent a different USB configuration or older firmware)
+- `0x126x` range: confirmed by real hardware and linux-usb.org:
+  - `0x1260` = iPod Nano 2G
+  - `0x1261` = iPod Classic
+  - `0x1262` = iPod Nano 3G (confirmed on real hardware)
+  - `0x1263` = iPod Nano 4G
+  - `0x1265` = iPod Nano 5G
+  - `0x1266` = iPod Nano 6G
+  - `0x1267` = iPod Nano 7G
+
+**Work required:**
+- Audit the full table against linux-usb.org `usb.ids` database
+- Add the `0x126x` range with comments explaining both ranges exist
+- Verify which IDs are for DFU/WTF mode (0x1223, 0x1224, etc) and ensure they're excluded or marked
+- Add comments explaining the source and confidence level of each entry
+- Unit tests verifying all known IDs resolve correctly
+
+See PRD: doc-029 — "USB Product ID Table Fix" section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Product ID table includes both 0x120x and 0x126x ranges for all supported iPod generations
+- [x] #2 DFU/WTF mode IDs are excluded or clearly marked as non-disk-mode
+- [x] #3 Each entry has a comment indicating source (linux-usb.org, direct testing, community)
+- [x] #4 lookupIpodModel resolves 0x1262 to iPod Nano 3rd generation
+- [x] #5 Unit tests cover all entries in both ID ranges
+- [x] #6 UNSUPPORTED_IPODS list reviewed against new entries
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Combined with TASK-279.04 into unified model registry. Both 0x120x and 0x126x USB ID ranges present. DFU/WTF excluded. 0x1266 added to UNSUPPORTED_IPODS. All entries sourced from linux-usb.org and real hardware.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Rewrote ipod-models.ts as a unified model registry with:\n- USB product ID table expanded with 0x126x range (7 new entries confirmed by linux-usb.org and real hardware)\n- DFU/WTF mode IDs excluded by design\n- Source attribution comments on all sections\n- lookupIpodModel resolves 0x1262 to iPod nano 3rd generation\n- 68 unit tests covering all ID ranges\n- Comment noting 0x1266 needs adding to UNSUPPORTED_IPODS in usb-discovery.ts
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.04 - Add-serial-suffix-→-model-lookup-to-podkit-core.md
+++ b/backlog/tasks/task-279.04 - Add-serial-suffix-→-model-lookup-to-podkit-core.md
@@ -1,0 +1,64 @@
+---
+id: TASK-279.04
+title: Add serial suffix → model lookup to podkit-core
+status: Done
+assignee: []
+created_date: '2026-04-19 17:12'
+updated_date: '2026-04-19 17:40'
+labels:
+  - device
+dependencies: []
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: medium
+ordinal: 4000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the serial number suffix → model lookup capability to podkit-core. libgpod identifies exact iPod models (including color and capacity) from the last 3 characters of the device serial number. This mapping needs to be available in podkit-core for display purposes during device add and doctor.
+
+**What to copy from libgpod:**
+- The `serial_to_model_mapping` table from `itdb_device.c` (lines 633-743+) — maps 3-char serial suffixes to model numbers (e.g., "YXX" → "B261")
+- This combined with the existing model number → display name lookup gives exact identification (e.g., "B261" → "iPod nano 8GB Black (3rd Generation)")
+
+**What to copy from ipod-db:**
+- The `MODEL_TABLE` from `packages/ipod-db/src/device/models.ts` has richer data per model (generation, capacity, color via model field like `nano_black`, musicDirs)
+- Copy the relevant subset into podkit-core with clear comments noting duplication and referencing ipod-db as future single source of truth
+
+**New unified model registry in podkit-core:**
+- Single module with multiple access patterns: by USB product ID, by ModelNumStr, by serial suffix
+- Replaces the current separate `IPOD_MODELS` and `SYSINFO_MODEL_NAMES` tables in `ipod-models.ts`
+- Include generation-to-checksum-type mapping (none/hash58/hash72/hashAB) for initialization capability detection
+
+**Verified on real hardware:**
+- iPod Nano 3G serial `5U8280FNYXX` → suffix "YXX" → model "B261" → "iPod nano 8GB Black (3rd Generation)"
+
+See PRD: doc-029 — "Initialization Capability Mapping" and "Refactoring Opportunities: Model table consolidation" sections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Serial suffix lookup function: given 3-char suffix returns model info (generation, capacity, color, display name)
+- [x] #2 Checksum type mapping: each generation maps to none/hash58/hash72/hashAB
+- [x] #3 Existing lookupIpodModel and lookupIpodModelByNumber functions still work (refactored into unified registry)
+- [x] #4 Code copied from ipod-db has clear comments noting duplication and referencing ipod-db as future source of truth
+- [x] #5 Unit tests verify known serial suffixes (e.g., YXX → nano 3G black 8GB)
+- [x] #6 Unit tests verify checksum type mapping for each generation category
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Unified registry in ipod-models.ts with serial suffix lookup (190+ entries from libgpod), checksum type mapping per generation, and backward-compatible lookupIpodModel/lookupIpodModelByNumber. New types and functions exported from device/index.ts. 68 new tests.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added to unified ipod-models.ts:\n- Serial suffix -> model lookup (190+ entries from libgpod itdb_device.c lines 633-868)\n- Checksum type mapping for all 27 generation IDs (none/hash58/hash72/hashAB)\n- Model number registry with 150+ entries including generation, capacity, and color\n- lookupIpodModelBySerial, getGenerationInfo, getChecksumType, lookupGenerationByProductId functions\n- Backward-compatible lookupIpodModel and lookupIpodModelByNumber preserved\n- Duplication with ipod-db noted in comments for future consolidation\n- Full test coverage including end-to-end identification pipeline tests
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.05 - Build-SysInfoExtended-orchestrator.md
+++ b/backlog/tasks/task-279.05 - Build-SysInfoExtended-orchestrator.md
@@ -1,0 +1,61 @@
+---
+id: TASK-279.05
+title: Build SysInfoExtended orchestrator
+status: To Do
+assignee: []
+created_date: '2026-04-19 17:12'
+labels:
+  - device
+  - usb
+dependencies:
+  - TASK-279.01
+  - TASK-279.02
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: high
+ordinal: 5000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create the core orchestrator module in podkit-core that coordinates reading SysInfoExtended from iPod firmware and writing it to the device filesystem. This is the deep module — simple interface, encapsulates USB transfer, XML validation, and file I/O.
+
+**Interface:**
+```
+ensureSysInfoExtended(mountPoint, usbInfo: { bus, address }) → Result
+```
+
+**Behavior:**
+1. Check if `iPod_Control/Device/SysInfoExtended` already exists on device — if so, skip (return existing)
+2. Call libgpod-node binding `readSysInfoExtendedFromUsb(bus, address)` to read XML from firmware
+3. Validate returned XML: well-formed, contains expected keys (FireWireGUID, SerialNumber, FamilyID, DBVersion)
+4. Write XML to `iPod_Control/Device/SysInfoExtended`
+5. Optionally extract key fields for display (serial → model lookup using task-279.04's registry)
+6. Return result: success with device info, or failure with reason
+
+**Error cases:**
+- USB read returns null → "Could not read device identity from USB"
+- XML missing FireWireGUID → "Device returned incomplete identity data"
+- Mount point not writable → appropriate filesystem error
+- Device directory doesn't exist → create it
+
+**Platform-agnostic:** This module accepts bus/address (obtained by task-279.02's USB discovery) and calls the binding (exposed by task-279.01). No platform-specific code in this module.
+
+See PRD: doc-029 — "SysInfoExtended Orchestrator" section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 ensureSysInfoExtended writes XML to iPod_Control/Device/SysInfoExtended when file is missing
+- [ ] #2 ensureSysInfoExtended skips writing when SysInfoExtended already exists
+- [ ] #3 Returns extracted device info (FirewireGuid, serial, model name) on success
+- [ ] #4 Returns clear error message when USB read fails
+- [ ] #5 Validates XML contains FireWireGUID and SerialNumber keys
+- [ ] #6 Creates Device directory if it doesn't exist
+- [ ] #7 Unit tests with fixture XML verify write, skip, and error paths
+- [ ] #8 Unit tests verify XML validation catches missing required keys
+<!-- AC:END -->

--- a/backlog/tasks/task-279.05 - Build-SysInfoExtended-orchestrator.md
+++ b/backlog/tasks/task-279.05 - Build-SysInfoExtended-orchestrator.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-279.05
 title: Build SysInfoExtended orchestrator
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 17:12'
+updated_date: '2026-04-25 13:40'
 labels:
   - device
   - usb
@@ -50,12 +51,18 @@ See PRD: doc-029 — "SysInfoExtended Orchestrator" section.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 ensureSysInfoExtended writes XML to iPod_Control/Device/SysInfoExtended when file is missing
-- [ ] #2 ensureSysInfoExtended skips writing when SysInfoExtended already exists
-- [ ] #3 Returns extracted device info (FirewireGuid, serial, model name) on success
-- [ ] #4 Returns clear error message when USB read fails
-- [ ] #5 Validates XML contains FireWireGUID and SerialNumber keys
-- [ ] #6 Creates Device directory if it doesn't exist
-- [ ] #7 Unit tests with fixture XML verify write, skip, and error paths
-- [ ] #8 Unit tests verify XML validation catches missing required keys
+- [x] #1 ensureSysInfoExtended writes XML to iPod_Control/Device/SysInfoExtended when file is missing
+- [x] #2 ensureSysInfoExtended skips writing when SysInfoExtended already exists
+- [x] #3 Returns extracted device info (FirewireGuid, serial, model name) on success
+- [x] #4 Returns clear error message when USB read fails
+- [x] #5 Validates XML contains FireWireGUID and SerialNumber keys
+- [x] #6 Creates Device directory if it doesn't exist
+- [x] #7 Unit tests with fixture XML verify write, skip, and error paths
+- [x] #8 Unit tests verify XML validation catches missing required keys
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+New module sysinfo-extended.ts with ensureSysInfoExtended (USB read + write) and readSysInfoExtended (read-only). Dependency injection for testing via optional readFromUsb parameter. Regex-based plist parsing handles both FireWireGUID/FirewireGuid casing. 17 tests.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-279.06 - Update-readiness-pipeline-and-doctor-for-SysInfoExtended.md
+++ b/backlog/tasks/task-279.06 - Update-readiness-pipeline-and-doctor-for-SysInfoExtended.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-279.06
 title: Update readiness pipeline and doctor for SysInfoExtended
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 17:12'
+updated_date: '2026-04-25 13:40'
 labels:
   - device
   - cli
@@ -46,12 +47,52 @@ See PRD: doc-029 — "Readiness Pipeline Update" and "Initialization Capability 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 SysInfo readiness stage passes when SysInfoExtended is present
-- [ ] #2 SysInfo readiness stage warns when only SysInfo is present (no SysInfoExtended)
-- [ ] #3 SysInfo readiness stage fails when both are missing, with repair suggestion
-- [ ] #4 doctor --repair sysinfo-extended triggers SysInfoExtended read from USB and writes to device
-- [ ] #5 Hash72 devices show clear message about iTunes sync requirement
-- [ ] #6 HashAB devices show clear message about proprietary component requirement
-- [ ] #7 Existing readiness tests updated to cover new SysInfoExtended states
-- [ ] #8 Doctor repair follows existing pattern (artwork-rebuild style)
+- [x] #1 SysInfo readiness stage passes when SysInfoExtended is present
+- [x] #2 SysInfo readiness stage warns when only SysInfo is present (no SysInfoExtended)
+- [x] #3 SysInfo readiness stage fails when both are missing, with repair suggestion
+- [x] #4 doctor --repair sysinfo-extended triggers SysInfoExtended read from USB and writes to device
+- [x] #5 Hash72 devices show clear message about iTunes sync requirement
+- [x] #6 HashAB devices show clear message about proprietary component requirement
+- [x] #7 Existing readiness tests updated to cover new SysInfoExtended states
+- [x] #8 Doctor repair follows existing pattern (artwork-rebuild style)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated checkSysInfo to check SysInfoExtended first. Checksum type severity: hash58+ without SysInfoExtended → fail, none → warn. Added checksumNote for hash72/hashAB. New sysinfo-extended diagnostic check with repair via resolveUsbDeviceFromPath + ensureSysInfoExtended. Registered in diagnostics index. 40 readiness tests pass.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Updated readiness pipeline and diagnostics framework for SysInfoExtended support.
+
+**Readiness pipeline (`readiness.ts`):**
+- `checkSysInfo` now checks SysInfoExtended first via `readSysInfoExtended(mountPoint)`
+- SysInfoExtended present with valid content → **pass** (uses richer device info)
+- SysInfo present but SysInfoExtended missing → **warn** (no-checksum devices) or **fail** (hash58/hash72/hashAB devices)
+- Both missing → **fail** with suggestion to run `podkit doctor --repair sysinfo-extended`
+- Checksum severity determined from USB product ID (via `usbInfo` parameter) or SysInfoExtended serial suffix
+- Hash72 devices get informational note about iTunes sync requirement for HashInfo bootstrapping
+- HashAB devices get informational note about proprietary component requirement
+- `checkSysInfo` signature updated: `(mountPoint, usbInfo?)` — backward-compatible
+- `ReadinessInput` interface extended with optional `usbInfo?: UsbDeviceInfo`
+- `checkReadiness` pipeline passes `input.usbInfo` to `checkSysInfo`
+- `determineLevel` logic unchanged — existing mappings handle new warn/fail states correctly
+
+**Diagnostic check (`diagnostics/checks/sysinfo-extended.ts`):**
+- New check ID: `sysinfo-extended`, name: "SysInfoExtended"
+- `applicableTo: ['ipod']`
+- Detection: checks if SysInfoExtended exists and has valid device info
+- Repair: resolves USB device via `resolveUsbDeviceFromPath`, calls `ensureSysInfoExtended`
+- Requirements: `['writable-device']`
+- Supports dry-run mode
+- Registered in diagnostics index
+
+**Tests:**
+- 40 readiness tests pass (up from 34)
+- New tests: SysInfoExtended pass, SysInfoExtended-only pass, SysInfo-only warn, both-missing fail, hash58 fail severity, hash72/hashAB checksum notes
+- Existing tests updated to reflect new warn behavior for SysInfo-only scenarios
+- All 2393 @podkit/core tests pass, build clean
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-279.06 - Update-readiness-pipeline-and-doctor-for-SysInfoExtended.md
+++ b/backlog/tasks/task-279.06 - Update-readiness-pipeline-and-doctor-for-SysInfoExtended.md
@@ -1,0 +1,57 @@
+---
+id: TASK-279.06
+title: Update readiness pipeline and doctor for SysInfoExtended
+status: To Do
+assignee: []
+created_date: '2026-04-19 17:12'
+labels:
+  - device
+  - cli
+dependencies:
+  - TASK-279.05
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: high
+ordinal: 6000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the readiness pipeline's SysInfo stage and the doctor command to account for SysInfoExtended. Add a new repairable check that triggers the SysInfoExtended orchestrator.
+
+**Readiness pipeline changes (readiness.ts):**
+- SysInfo stage now checks for SysInfoExtended in addition to SysInfo
+- Pass: SysInfoExtended present with valid content, OR SysInfo present with valid ModelNumStr
+- Warn: SysInfo present but SysInfoExtended missing (device works but may lack full capability data)
+- Fail: both missing → suggest `podkit doctor --repair sysinfo-extended`
+- Use checksum type mapping (from task-279.04) to determine severity: hash58+ devices FAIL without SysInfoExtended, older devices WARN
+
+**Doctor command changes (doctor.ts):**
+- New repairable check ID: `sysinfo-extended`
+- Follow existing pattern from `artwork-rebuild` and `orphan-files` checks
+- `doctor --repair sysinfo-extended` triggers the orchestrator (from task-279.05)
+- Requires USB device info — resolve from device config's mount path using USB discovery (task-279.02)
+
+**Limitation messaging:**
+- Hash72 devices (Nano 5G): message explaining iTunes sync required for HashInfo bootstrap
+- HashAB devices (Nano 6G, Touch 4G): message explaining proprietary component requirement
+- These are informational messages, not repairable checks
+
+See PRD: doc-029 — "Readiness Pipeline Update" and "Initialization Capability Mapping" sections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 SysInfo readiness stage passes when SysInfoExtended is present
+- [ ] #2 SysInfo readiness stage warns when only SysInfo is present (no SysInfoExtended)
+- [ ] #3 SysInfo readiness stage fails when both are missing, with repair suggestion
+- [ ] #4 doctor --repair sysinfo-extended triggers SysInfoExtended read from USB and writes to device
+- [ ] #5 Hash72 devices show clear message about iTunes sync requirement
+- [ ] #6 HashAB devices show clear message about proprietary component requirement
+- [ ] #7 Existing readiness tests updated to cover new SysInfoExtended states
+- [ ] #8 Doctor repair follows existing pattern (artwork-rebuild style)
+<!-- AC:END -->

--- a/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
+++ b/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
@@ -4,7 +4,7 @@ title: Integrate SysInfoExtended into device add flow
 status: Done
 assignee: []
 created_date: '2026-04-19 17:12'
-updated_date: '2026-04-25 14:56'
+updated_date: '2026-04-25 15:17'
 labels:
   - cli
   - device
@@ -49,7 +49,7 @@ See PRD: doc-029 — "CLI Integration: device add" section.
 - [x] #2 Device summary shows exact model name (color, capacity, generation) after SysInfoExtended is read
 - [x] #3 Works with both --path and auto-detected device paths
 - [x] #4 USB read failure produces a warning but does not block device add
-- [ ] #5 E2E test verifies device add flow attempts SysInfoExtended read when file is missing
+- [x] #5 E2E test verifies device add flow attempts SysInfoExtended read when file is missing
 - [x] #6 Existing device add tests still pass
 <!-- AC:END -->
 
@@ -57,4 +57,6 @@ See PRD: doc-029 — "CLI Integration: device add" section.
 
 <!-- SECTION:NOTES:BEGIN -->
 Added attemptSysInfoExtended helper in device.ts CLI. Called in both explicit-path and auto-discovery flows after mount, before DB init. Enriches model name in device summary. Never blocks device add — all failures logged at verbose level. Added exports to @podkit/core top-level and demo mock stubs.
+
+AC #5: E2E test added in device.e2e.test.ts. Uses -vv verbose flag to assert 'SysInfoExtended' appears in output, proving attemptSysInfoExtended code path ran. Test passes in dummy iPod environment (no real USB device needed).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
+++ b/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
@@ -4,7 +4,7 @@ title: Integrate SysInfoExtended into device add flow
 status: Done
 assignee: []
 created_date: '2026-04-19 17:12'
-updated_date: '2026-04-25 13:45'
+updated_date: '2026-04-25 14:56'
 labels:
   - cli
   - device
@@ -56,12 +56,5 @@ See PRD: doc-029 — "CLI Integration: device add" section.
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Integrated SysInfoExtended into the `podkit device add` command in both iPod flows (explicit path and auto-discovery).
-
-**Changes:**
-1. `packages/podkit-cli/src/commands/device.ts` — Added `attemptSysInfoExtended()` helper and integrated it into both add paths
-2. `packages/podkit-core/src/index.ts` — Added re-exports for `readSysInfoExtended`, `ensureSysInfoExtended`, `resolveUsbDeviceFromPath`, and `SysInfoExtendedResult` (were exported from device/index.ts but not from top-level)
-3. `packages/demo/src/mock-core.ts` — Added stub implementations for the three new exports
-
-AC #5 (E2E test) was out of scope per task description.
+Added attemptSysInfoExtended helper in device.ts CLI. Called in both explicit-path and auto-discovery flows after mount, before DB init. Enriches model name in device summary. Never blocks device add — all failures logged at verbose level. Added exports to @podkit/core top-level and demo mock stubs.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
+++ b/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-279.07
 title: Integrate SysInfoExtended into device add flow
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 17:12'
+updated_date: '2026-04-25 13:45'
 labels:
   - cli
   - device
@@ -44,10 +45,23 @@ See PRD: doc-029 — "CLI Integration: device add" section.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 device add automatically reads SysInfoExtended when missing on a mounted iPod
-- [ ] #2 Device summary shows exact model name (color, capacity, generation) after SysInfoExtended is read
-- [ ] #3 Works with both --path and auto-detected device paths
-- [ ] #4 USB read failure produces a warning but does not block device add
+- [x] #1 device add automatically reads SysInfoExtended when missing on a mounted iPod
+- [x] #2 Device summary shows exact model name (color, capacity, generation) after SysInfoExtended is read
+- [x] #3 Works with both --path and auto-detected device paths
+- [x] #4 USB read failure produces a warning but does not block device add
 - [ ] #5 E2E test verifies device add flow attempts SysInfoExtended read when file is missing
-- [ ] #6 Existing device add tests still pass
+- [x] #6 Existing device add tests still pass
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Integrated SysInfoExtended into the `podkit device add` command in both iPod flows (explicit path and auto-discovery).
+
+**Changes:**
+1. `packages/podkit-cli/src/commands/device.ts` — Added `attemptSysInfoExtended()` helper and integrated it into both add paths
+2. `packages/podkit-core/src/index.ts` — Added re-exports for `readSysInfoExtended`, `ensureSysInfoExtended`, `resolveUsbDeviceFromPath`, and `SysInfoExtendedResult` (were exported from device/index.ts but not from top-level)
+3. `packages/demo/src/mock-core.ts` — Added stub implementations for the three new exports
+
+AC #5 (E2E test) was out of scope per task description.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
+++ b/backlog/tasks/task-279.07 - Integrate-SysInfoExtended-into-device-add-flow.md
@@ -1,0 +1,53 @@
+---
+id: TASK-279.07
+title: Integrate SysInfoExtended into device add flow
+status: To Do
+assignee: []
+created_date: '2026-04-19 17:12'
+labels:
+  - cli
+  - device
+dependencies:
+  - TASK-279.05
+  - TASK-279.06
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: high
+ordinal: 7000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Integrate automatic SysInfoExtended reading into the `podkit device add` command. When adding an iPod that lacks SysInfoExtended, podkit should automatically read it from firmware via USB before proceeding with database init/open.
+
+**device add flow changes (device.ts):**
+- After mounting and before database init/open, check for SysInfoExtended
+- If missing: resolve USB bus/address (using task-279.02's path-to-USB correlation for --path case, or from USB discovery for auto-detected case)
+- Call orchestrator (task-279.05) to read and write SysInfoExtended
+- Show result in device summary: exact model name from serial → model lookup (e.g., "iPod nano 8GB Black (3rd Generation)")
+- If USB read fails: warn but continue (device may still work for older models that don't need checksums)
+
+**Both add paths affected:**
+- Explicit path (`--path /Volumes/IPOD`): correlate path to USB device info, then orchestrate
+- Auto-detected (no --path): USB info already available from discovery, pass to orchestrator
+
+**Display enhancements:**
+- Device summary during add shows exact model (color, capacity, generation) instead of "Unknown"
+- If SysInfoExtended was just written, indicate this (e.g., "Device identified: iPod nano 8GB Black (3rd Generation)")
+
+See PRD: doc-029 — "CLI Integration: device add" section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 device add automatically reads SysInfoExtended when missing on a mounted iPod
+- [ ] #2 Device summary shows exact model name (color, capacity, generation) after SysInfoExtended is read
+- [ ] #3 Works with both --path and auto-detected device paths
+- [ ] #4 USB read failure produces a warning but does not block device add
+- [ ] #5 E2E test verifies device add flow attempts SysInfoExtended read when file is missing
+- [ ] #6 Existing device add tests still pass
+<!-- AC:END -->

--- a/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
+++ b/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
@@ -1,0 +1,57 @@
+---
+id: TASK-279.08
+title: Refactor model tables and USB tree traversal
+status: To Do
+assignee: []
+created_date: '2026-04-19 17:13'
+labels:
+  - refactoring
+  - device
+dependencies:
+  - TASK-279.03
+  - TASK-279.04
+documentation:
+  - >-
+    backlog/docs/doc-029 - PRD: Automated iPod Device Identification via
+    SysInfoExtended.md
+parent_task_id: TASK-279
+priority: low
+ordinal: 8000
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Cleanup and refactoring task to improve code quality after the main feature work. Addresses technical debt identified during the SysInfoExtended PRD investigation.
+
+**Model table cleanup:**
+- After task-279.04 creates the unified model registry, remove the old separate `IPOD_MODELS` and `SYSINFO_MODEL_NAMES` tables from `ipod-models.ts`
+- Ensure all consumers use the new unified registry
+- Verify no dead code remains
+
+**macOS USB tree traversal consolidation:**
+- `macos.ts` has duplicated recursive tree walks: `findAllBsdNamesForDevice()` and `findUsbDeviceByBsdName()`
+- Extract a generic tree search utility with predicate/collector callbacks
+- Both functions should delegate to the shared utility
+- Also consolidate with new path-to-USB correlation (from task-279.02)
+
+**Readiness pipeline clarity:**
+- `determineLevel()` is a growing switch/case — restructure as ordered rules list for clarity
+- Not a full plugin system (over-engineering), just clearer conditional logic
+
+**Platform device manager alignment:**
+- Tighten shared interfaces so macOS and Linux provide the same USB info structure
+- Ensures the SysInfoExtended orchestrator is fully platform-agnostic
+
+See PRD: doc-029 — "Refactoring Opportunities" section.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Old separate IPOD_MODELS and SYSINFO_MODEL_NAMES tables removed, all consumers use unified registry
+- [ ] #2 macOS USB tree traversal uses shared generic search utility (no duplicated recursive walks)
+- [ ] #3 determineLevel() restructured for clarity (ordered rules, not nested conditionals)
+- [ ] #4 macOS and Linux device managers provide consistent USB info interface
+- [ ] #5 All existing tests pass after refactoring
+- [ ] #6 No functional behavior changes — refactoring only
+<!-- AC:END -->

--- a/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
+++ b/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
@@ -4,6 +4,7 @@ title: Refactor model tables and USB tree traversal
 status: To Do
 assignee: []
 created_date: '2026-04-19 17:13'
+updated_date: '2026-04-25 14:56'
 labels:
   - refactoring
   - device
@@ -48,10 +49,16 @@ See PRD: doc-029 — "Refactoring Opportunities" section.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Old separate IPOD_MODELS and SYSINFO_MODEL_NAMES tables removed, all consumers use unified registry
+- [x] #1 Old separate IPOD_MODELS and SYSINFO_MODEL_NAMES tables removed, all consumers use unified registry
 - [ ] #2 macOS USB tree traversal uses shared generic search utility (no duplicated recursive walks)
 - [ ] #3 determineLevel() restructured for clarity (ordered rules, not nested conditionals)
 - [ ] #4 macOS and Linux device managers provide consistent USB info interface
 - [ ] #5 All existing tests pass after refactoring
 - [ ] #6 No functional behavior changes — refactoring only
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC #1 (remove old separate tables) already done in phase 1 when 279.03+04 were combined into unified registry. Remaining ACs (tree traversal consolidation, determineLevel cleanup, platform alignment) are deferred as low-priority refactoring for a follow-up PR.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
+++ b/backlog/tasks/task-279.08 - Refactor-model-tables-and-USB-tree-traversal.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-279.08
 title: Refactor model tables and USB tree traversal
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-04-19 17:13'
-updated_date: '2026-04-25 14:56'
+updated_date: '2026-04-25 17:06'
 labels:
   - refactoring
   - device
@@ -50,15 +50,15 @@ See PRD: doc-029 — "Refactoring Opportunities" section.
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 Old separate IPOD_MODELS and SYSINFO_MODEL_NAMES tables removed, all consumers use unified registry
-- [ ] #2 macOS USB tree traversal uses shared generic search utility (no duplicated recursive walks)
-- [ ] #3 determineLevel() restructured for clarity (ordered rules, not nested conditionals)
-- [ ] #4 macOS and Linux device managers provide consistent USB info interface
-- [ ] #5 All existing tests pass after refactoring
-- [ ] #6 No functional behavior changes — refactoring only
+- [x] #2 macOS USB tree traversal uses shared generic search utility (no duplicated recursive walks)
+- [x] #3 determineLevel() restructured for clarity (ordered rules, not nested conditionals)
+- [x] #4 macOS and Linux device managers provide consistent USB info interface
+- [x] #5 All existing tests pass after refactoring
+- [x] #6 No functional behavior changes — refactoring only
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-AC #1 (remove old separate tables) already done in phase 1 when 279.03+04 were combined into unified registry. Remaining ACs (tree traversal consolidation, determineLevel cleanup, platform alignment) are deferred as low-priority refactoring for a follow-up PR.
+AC#2: Extracted findUsbDeviceNode() as shared recursive search. Both findAllBsdNamesForDevice and findUsbDeviceByBsdName delegate to it. AC#3: determineLevel() restructured as READINESS_RULES ordered array with match predicates. AC#4: macOS extracts serial_num/location_id, Linux reads serial/busnum/devnum from sysfs. All 2394 tests pass.
 <!-- SECTION:NOTES:END -->

--- a/bun.lock
+++ b/bun.lock
@@ -2069,13 +2069,13 @@
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
-    "@podkit/gpod-testing/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@podkit/gpod-testing/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@podkit/ipod-db/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@podkit/ipod-db/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@podkit/ipod-web/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@podkit/ipod-web/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@podkit/libgpod-node/@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@podkit/libgpod-node/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2171,13 +2171,13 @@
 
     "@manypkg/cli/@manypkg/get-packages/@manypkg/find-root": ["@manypkg/find-root@3.1.0", "", { "dependencies": { "@manypkg/tools": "^2.1.0" } }, "sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA=="],
 
-    "@podkit/gpod-testing/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@podkit/gpod-testing/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@podkit/ipod-db/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@podkit/ipod-db/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@podkit/ipod-web/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@podkit/ipod-web/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@podkit/libgpod-node/@types/bun/bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "@podkit/libgpod-node/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/devices/ipod.md
+++ b/devices/ipod.md
@@ -261,7 +261,7 @@ with a companion ArtworkDB.
 iPod_Control/
 ├── Device/
 │   ├── SysInfo              # Model identification
-│   └── SysInfoExtended      # Capabilities (iTunes-created)
+│   └── SysInfoExtended      # Capabilities (written by libgpod tooling via SCSI)
 ├── iTunes/
 │   ├── iTunesDB             # Main binary database
 │   ├── iTunesPrefs          # Device preferences
@@ -319,9 +319,10 @@ iPod_Control/
   not write. iTunes handles this natively.
 - **H.264 High profile** — not supported on any iPod generation. Must use
   Baseline or Main profile.
-- **SysInfoExtended** — capabilities file created by iTunes. May not exist if
-  the iPod was never synced with iTunes. libgpod can work without it but some
-  features may be limited.
+- **SysInfoExtended** — capabilities file extracted via SCSI commands by
+  `ipod-read-sysinfo-extended` (a libgpod tool). Not written by iTunes or
+  firmware. May not exist on devices that have never been set up with libgpod
+  tooling. libgpod can work without it but some features may be limited.
 
 ## Research Notes
 

--- a/docs/devices/ipod-internals.md
+++ b/docs/devices/ipod-internals.md
@@ -13,7 +13,7 @@ This document covers the internal structure of iPod devices, focusing on the dat
 iPod_Control/
 ├── Device/
 │   ├── SysInfo              # Device model information
-│   └── SysInfoExtended      # Detailed device capabilities (iTunes-created)
+│   └── SysInfoExtended      # Detailed device capabilities (written by libgpod tooling)
 ├── iTunes/
 │   ├── iTunesDB             # Main track database (binary)
 │   ├── iTunesPrefs          # Device preferences
@@ -76,7 +76,9 @@ Using just `A147` would skip 'A' and look for '147', which doesn't exist.
 
 ### Creating SysInfo Manually
 
-If an iPod doesn't have a SysInfo file (common after reformatting):
+On pre-2006 iPods (1G–5G, Nano 1G), the firmware writes a populated SysInfo file automatically during reset or restore. On later models (Classic, Nano 2G+, 5.5G+, Shuffle 2G+), the firmware either creates an empty (0-byte) SysInfo or nothing at all after an iTunes restore — libgpod writes the populated SysInfo during `itdb_init_ipod`. If SysInfo is missing or empty after a reformat, create it manually:
+
+If an iPod doesn't have a populated SysInfo file:
 
 ```bash
 IPOD="/media/username/IPOD"

--- a/docs/devices/ipod-internals.md
+++ b/docs/devices/ipod-internals.md
@@ -12,8 +12,8 @@ This document covers the internal structure of iPod devices, focusing on the dat
 ```
 iPod_Control/
 ├── Device/
-│   ├── SysInfo              # Device model information
-│   └── SysInfoExtended      # Detailed device capabilities (written by libgpod tooling)
+│   ├── SysInfo              # Device model number (plain text key-value)
+│   └── SysInfoExtended      # Device identity — serial, FirewireGuid (Apple plist XML)
 ├── iTunes/
 │   ├── iTunesDB             # Main track database (binary)
 │   ├── iTunesPrefs          # Device preferences
@@ -35,9 +35,10 @@ The `SysInfo` file in `iPod_Control/Device/` identifies the iPod model to softwa
 
 ### Format
 
+Plain text key-value pairs:
+
 ```
 ModelNumStr: MA147
-FirewireGuid: XXXXXXXXXXXXXXXX
 ```
 
 ### Model Numbers
@@ -84,6 +85,45 @@ If an iPod doesn't have a populated SysInfo file:
 IPOD="/media/username/IPOD"
 echo "ModelNumStr: MA147" > "$IPOD/iPod_Control/Device/SysInfo"
 ```
+
+## SysInfoExtended File
+
+The `SysInfoExtended` file in `iPod_Control/Device/` is an Apple plist XML file containing detailed device identity information. It is read from the iPod's firmware via USB vendor control transfers — it is not created by editing a text file.
+
+### What it contains
+
+- **FireWireGUID**: 16-character hex device identifier
+- **SerialNumber**: 11-character serial number (last 3 characters identify the exact model variant — color, capacity)
+- **ModelNumber**, **FamilyID**, **DBVersion**: Internal device metadata
+
+### Why it matters
+
+On newer iPods (Classic 6G/7G, Nano 3G+), the iTunesDB must be signed with an HMAC checksum derived from the device's FireWireGUID. Without SysInfoExtended, libgpod cannot compute this checksum, the iPod rejects the database, and the device shows "No Music".
+
+Older iPods (Video 5G/5.5G, Nano 1G–2G, Mini, Shuffle) do not require checksums. These devices work fine with just a SysInfo file containing `ModelNumStr`.
+
+### SysInfo vs SysInfoExtended
+
+| | SysInfo | SysInfoExtended |
+|---|---|---|
+| **Format** | Plain text key-value | Apple plist XML |
+| **Key data** | `ModelNumStr` (model identification) | `FireWireGUID` (database checksums), `SerialNumber` (exact variant ID) |
+| **Created by** | `gpod-tool init`, iTunes, or manually | iPod firmware (read via USB) |
+| **Used by libgpod for** | Model lookup → generation, artwork formats, codec support | Database checksum signing (hash58+ devices) |
+| **Required on older iPods** | Yes | No |
+| **Required on newer iPods** | Either SysInfo or SysInfoExtended | Yes — without it, database writes fail |
+
+When both files are present, libgpod prefers SysInfoExtended.
+
+### Getting SysInfoExtended
+
+podkit reads SysInfoExtended from the iPod firmware automatically during `podkit device add`. If the file is missing, you can repair it:
+
+```bash
+podkit doctor --repair sysinfo-extended
+```
+
+This reads the device identity from USB and writes the file to the iPod. It does not modify any music, playlists, or database content.
 
 ## iTunesDB Format
 
@@ -198,9 +238,9 @@ Each file contains concatenated images for multiple tracks.
 
 ### Artwork Requirements
 
-1. **SysInfo must exist** - libgpod needs model info for format selection
-2. **Artwork directory must exist** - Create `iPod_Control/Artwork/` if missing
-3. **Source image** - JPEG or PNG, any size (libgpod resizes)
+1. **SysInfo must exist with `ModelNumStr`** — libgpod uses the model number to determine which artwork formats and sizes the device supports
+2. **Artwork directory must exist** — Create `iPod_Control/Artwork/` if missing
+3. **Source image** — JPEG or PNG, any size (libgpod resizes)
 
 ### Fixing Missing Artwork
 

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -544,7 +544,7 @@ The pipeline runs six stages in sequence. A failure at any stage skips remaining
 | Partition Table | Device has a recognizable partition table |
 | Filesystem | Partition contains a FAT32 filesystem |
 | Mounted | Filesystem is mounted and accessible |
-| SysInfo | `iPod_Control/Device/SysInfo` exists and is readable |
+| SysInfo | `SysInfo` or `SysInfoExtended` exists; newer iPods require `SysInfoExtended` for checksums |
 | Database | `iPod_Control/iTunes/iTunesDB` exists and can be opened |
 
 ## `podkit collection`

--- a/docs/user-guide/devices/doctor.md
+++ b/docs/user-guide/devices/doctor.md
@@ -51,6 +51,7 @@ If problems are detected, doctor tells you what's wrong and how to fix it. Devic
 | **Artwork Integrity** | Corrupted artwork database — wrong album art, glitched images, artwork from other albums | Failure |
 | **Encoder Availability** | Missing FFmpeg encoders for codecs in your [preference stack](/user-guide/transcoding/codec-preferences) | Warning |
 | **Orphan Files** | Unreferenced audio/video files wasting storage space | Warning |
+| **SysInfoExtended** | Missing device identity file required for database checksums on newer iPods | Failure (repair-only) |
 
 ### Mass-Storage Devices
 
@@ -140,6 +141,18 @@ podkit doctor -d mydevice --repair orphan-files-mass-storage
 ```
 
 Files outside the content directories are always ignored — doctor only considers directories that podkit manages. The `--delete` flag during sync also respects this boundary: it only removes files that podkit placed on the device.
+
+## Repairing Missing SysInfoExtended
+
+Newer iPods (Classic 6G/7G, Nano 3G+) require a `SysInfoExtended` file for database checksum signing. Without it, the iPod rejects the database after a sync and shows "No Music". If `podkit device scan` or `podkit doctor` reports a SysInfoExtended failure, repair it:
+
+```bash
+podkit doctor --repair sysinfo-extended
+```
+
+This reads the device identity from the iPod's firmware via USB and writes the `SysInfoExtended` file to `iPod_Control/Device/`. It does not modify music, playlists, or database content.
+
+Older iPods (Video 5G/5.5G, Nano 1G–2G, Mini, Shuffle) do not need SysInfoExtended — a SysInfo file with the correct `ModelNumStr` is sufficient. See [iPod Internals — SysInfoExtended](/devices/ipod-internals#sysinfoextended-file) for technical details.
 
 ## Previewing Repairs
 

--- a/packages/demo/src/mock-core.ts
+++ b/packages/demo/src/mock-core.ts
@@ -2336,6 +2336,18 @@ export async function discoverUsbIpods(): Promise<any[]> {
   return [];
 }
 
+export async function resolveUsbDeviceFromPath(_mountPath: string): Promise<any> {
+  return null;
+}
+
+export function readSysInfoExtended(_mountPoint: string): any {
+  return null;
+}
+
+export async function ensureSysInfoExtended(_mountPoint: string, _usbAddress: any): Promise<any> {
+  return { present: false, source: 'unavailable', error: 'Not available in demo mode' };
+}
+
 export function createUsbOnlyReadinessResult(_device: any): any {
   return { level: 'needs-partition', stages: [] };
 }

--- a/packages/demo/src/mock-core.ts
+++ b/packages/demo/src/mock-core.ts
@@ -2348,6 +2348,10 @@ export async function ensureSysInfoExtended(_mountPoint: string, _usbAddress: an
   return { present: false, source: 'unavailable', error: 'Not available in demo mode' };
 }
 
+export function getChecksumTypeByModelNumber(_modelNumStr: string): string | undefined {
+  return undefined;
+}
+
 export function createUsbOnlyReadinessResult(_device: any): any {
   return { level: 'needs-partition', stages: [] };
 }

--- a/packages/e2e-tests/src/commands/device.e2e.test.ts
+++ b/packages/e2e-tests/src/commands/device.e2e.test.ts
@@ -155,6 +155,42 @@ volumeName = "test"
     });
   });
 
+  describe('SysInfoExtended', () => {
+    it('attempts SysInfoExtended read when file is missing', async () => {
+      await withTarget(async (target) => {
+        // Ensure SysInfoExtended doesn't exist
+        const sysInfoExtPath = join(target.path, 'iPod_Control', 'Device', 'SysInfoExtended');
+        try {
+          await rm(sysInfoExtPath);
+        } catch {
+          /* may not exist */
+        }
+
+        await writeFile(configPath, 'version = 1\n');
+
+        const result = await runCli([
+          '--config',
+          configPath,
+          '--device',
+          'testipod',
+          '-vv',
+          'device',
+          'add',
+          '--path',
+          target.path,
+          '--yes',
+        ]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('added to config');
+
+        // Verify the SysInfoExtended code path was entered —
+        // verbose output should show the USB resolution attempt failed gracefully
+        expect(result.stdout).toContain('SysInfoExtended');
+      });
+    });
+  });
+
   describe('with uninitialized device', () => {
     let uninitDir: string;
 

--- a/packages/e2e-tests/src/commands/device.e2e.test.ts
+++ b/packages/e2e-tests/src/commands/device.e2e.test.ts
@@ -826,6 +826,40 @@ describe('podkit doctor with readiness', () => {
 });
 
 // =============================================================================
+// Doctor repair options
+// =============================================================================
+
+describe('podkit doctor --repair', () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'podkit-doctor-repair-'));
+    configPath = join(tempDir, 'config.toml');
+    await writeFile(configPath, 'version = 1\n');
+  });
+
+  it('accepts sysinfo-extended as a valid repair check ID', async () => {
+    // Use a nonexistent device path — we just need to verify the option is
+    // accepted by the CLI parser (not rejected as "invalid choice")
+    const result = await runCli([
+      '--config',
+      configPath,
+      '--device',
+      join(tempDir, 'fake-ipod'),
+      'doctor',
+      '--repair',
+      'sysinfo-extended',
+    ]);
+
+    // Should fail because device doesn't exist, NOT because the option is invalid
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).not.toContain('is invalid');
+    expect(result.stderr).not.toContain('Allowed choices');
+  });
+});
+
+// =============================================================================
 // Device init with readiness-related behavior
 // =============================================================================
 

--- a/packages/e2e-tests/src/commands/device.e2e.test.ts
+++ b/packages/e2e-tests/src/commands/device.e2e.test.ts
@@ -156,14 +156,17 @@ volumeName = "test"
   });
 
   describe('SysInfoExtended', () => {
-    it('attempts SysInfoExtended read when file is missing', async () => {
+    it('attempts SysInfoExtended read when neither identity file is present', async () => {
       await withTarget(async (target) => {
-        // Ensure SysInfoExtended doesn't exist
-        const sysInfoExtPath = join(target.path, 'iPod_Control', 'Device', 'SysInfoExtended');
-        try {
-          await rm(sysInfoExtPath);
-        } catch {
-          /* may not exist */
+        // Remove BOTH identity files so the SysInfoExtended attempt fires.
+        // If either file is present, the device-add flow correctly skips.
+        const deviceDir = join(target.path, 'iPod_Control', 'Device');
+        for (const file of ['SysInfo', 'SysInfoExtended']) {
+          try {
+            await rm(join(deviceDir, file));
+          } catch {
+            /* may not exist */
+          }
         }
 
         await writeFile(configPath, 'version = 1\n');
@@ -184,8 +187,9 @@ volumeName = "test"
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('added to config');
 
-        // Verify the SysInfoExtended code path was entered —
-        // verbose output should show the USB resolution attempt failed gracefully
+        // Verify the SysInfoExtended code path was entered — verbose output
+        // should mention SysInfoExtended (USB resolution fails gracefully on
+        // the test target since there's no real USB device).
         expect(result.stdout).toContain('SysInfoExtended');
       });
     });

--- a/packages/libgpod-node/README.md
+++ b/packages/libgpod-node/README.md
@@ -115,6 +115,30 @@ gboolean success = itdb_cp_track_to_ipod(track, newFilePath.c_str(), &error);
 
 **Why:** Self-healing sync needs to upgrade track files in-place (e.g., MP3 → AAC) while preserving play counts, ratings, and playlist membership. Clearing `ipod_path` is critical because the iPod firmware uses the file extension to select the audio decoder — an AAC file stored with a `.mp3` extension will not play. libgpod also derives `filetype_marker` (a 4-byte binary field) from the destination extension, so the extension must match the content.
 
+### 6. SysInfoExtended USB Read: Custom libgpod Patch
+
+**libgpod behavior:** The upstream release tarball compiles `ipod-usb.c` only into a standalone binary (`ipod-read-sysinfo-extended`), not into the library. The function `read_sysinfo_extended_from_usb()` is not available to downstream consumers.
+
+**Our behavior:** The prebuild CI applies a patch that moves this function into the library as `itdb_read_sysinfo_extended_from_usb()`, compiled conditionally when `HAVE_LIBUSB` is set. The N-API binding resolves the symbol at runtime via `dlsym` rather than linking directly.
+
+```cpp
+// native/gpod_binding.cc — runtime symbol resolution
+typedef gchar *(*ReadSysInfoExtendedFn)(guint bus_number, guint device_address);
+static ReadSysInfoExtendedFn resolve_sysinfo_fn() {
+    static ReadSysInfoExtendedFn fn = reinterpret_cast<ReadSysInfoExtendedFn>(
+        dlsym(RTLD_DEFAULT, "itdb_read_sysinfo_extended_from_usb"));
+    return fn;
+}
+```
+
+**Why dlsym?** The function must work in shipped prebuilds (where libgpod is patched and statically linked with `--whole-archive`) AND in development environments where system libgpod may lack the symbol. `dlsym` resolves this gracefully — returns null when unavailable instead of failing at load time.
+
+**Why `--whole-archive`?** Since no code references the symbol at link time (only `dlsym` at runtime), the linker would normally discard `itdb_usb.o` from the static archive. `-Wl,-force_load` (macOS) and `-Wl,--whole-archive` (Linux) force all object files to be linked.
+
+**Build patch files:**
+- `tools/prebuild/patches/itdb_usb.c` — the C implementation
+- `tools/prebuild/patches/apply-sysinfo-usb.sh` — applies to fresh libgpod source tree
+
 ## API Reference
 
 ### Database Operations

--- a/packages/libgpod-node/native/gpod_binding.cc
+++ b/packages/libgpod-node/native/gpod_binding.cc
@@ -21,6 +21,17 @@
 #include "database_wrapper.h"
 #include "photo_database_wrapper.h"
 
+// Declaration for itdb_read_sysinfo_extended_from_usb from libgpod.
+// USB SysInfoExtended reading — resolved at runtime via dlsym so the binding
+// loads even when libgpod was built without HAVE_LIBUSB (e.g., system packages).
+#include <dlfcn.h>
+typedef gchar *(*ReadSysInfoExtendedFn)(guint bus_number, guint device_address);
+static ReadSysInfoExtendedFn resolve_sysinfo_fn() {
+    static ReadSysInfoExtendedFn fn = reinterpret_cast<ReadSysInfoExtendedFn>(
+        dlsym(RTLD_DEFAULT, "itdb_read_sysinfo_extended_from_usb"));
+    return fn;
+}
+
 /**
  * Parse an iPod database from a mountpoint.
  * @param mountpoint Path to iPod mount point
@@ -261,6 +272,47 @@ Napi::Value CreatePhotoDb(const Napi::CallbackInfo& info) {
 }
 
 /**
+ * Read SysInfoExtended XML from an iPod via USB vendor control transfer.
+ * This is a standalone function that does not require an open database.
+ *
+ * @param busNumber USB bus number
+ * @param deviceAddress USB device address
+ * @returns XML string or null if the read fails
+ */
+Napi::Value ReadSysInfoExtendedFromUsb(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 2) {
+        Napi::TypeError::New(env, "Expected 2 arguments: busNumber, deviceAddress").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    if (!info[0].IsNumber() || !info[1].IsNumber()) {
+        Napi::TypeError::New(env, "busNumber and deviceAddress must be numbers").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    unsigned int busNumber = info[0].As<Napi::Number>().Uint32Value();
+    unsigned int deviceAddress = info[1].As<Napi::Number>().Uint32Value();
+
+    ReadSysInfoExtendedFn fn = resolve_sysinfo_fn();
+    if (!fn) {
+        // libgpod was built without libusb support
+        return env.Null();
+    }
+
+    gchar *xml = fn(busNumber, deviceAddress);
+
+    if (xml == nullptr) {
+        return env.Null();
+    }
+
+    Napi::String result = Napi::String::New(env, xml);
+    g_free(xml);
+    return result;
+}
+
+/**
  * Module initialization.
  */
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -276,6 +328,9 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
     // Photo database functions
     exports.Set("parsePhotoDb", Napi::Function::New(env, ParsePhotoDb));
     exports.Set("createPhotoDb", Napi::Function::New(env, CreatePhotoDb));
+
+    // USB functions
+    exports.Set("readSysInfoExtendedFromUsb", Napi::Function::New(env, ReadSysInfoExtendedFromUsb));
 
     return exports;
 }

--- a/packages/libgpod-node/src/__tests__/sysinfo-extended-usb.test.ts
+++ b/packages/libgpod-node/src/__tests__/sysinfo-extended-usb.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Smoke test for readSysInfoExtendedFromUsb.
+ *
+ * Verifies the function is linked correctly in the native binding
+ * and doesn't crash when called with invalid arguments.
+ *
+ * In CI prebuilds, libgpod is built without libusb, so the underlying
+ * dlsym call returns null and the function gracefully returns null.
+ * On developer machines with libusb, it returns null for invalid
+ * bus/address. Either way: no crash, no throw.
+ */
+
+import { describe, it, expect } from 'bun:test';
+
+import { readSysInfoExtendedFromUsb, isNativeAvailable } from '../../src/index';
+
+describe('readSysInfoExtendedFromUsb', () => {
+  it('is exported and callable', () => {
+    expect(typeof readSysInfoExtendedFromUsb).toBe('function');
+  });
+
+  it('returns null for invalid bus/address without crashing', () => {
+    if (!isNativeAvailable()) {
+      console.log('Skipping: native binding not available');
+      return;
+    }
+
+    const result = readSysInfoExtendedFromUsb(99, 99);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/libgpod-node/src/binding.ts
+++ b/packages/libgpod-node/src/binding.ts
@@ -194,6 +194,9 @@ export interface NativeBinding {
   PhotoDatabase: new () => NativePhotoDatabase;
   parsePhotoDb(mountpoint: string): NativePhotoDatabase;
   createPhotoDb(mountpoint?: string): NativePhotoDatabase;
+
+  // USB functions
+  readSysInfoExtendedFromUsb(busNumber: number, deviceAddress: number): string | null;
 }
 
 // Cached binding reference
@@ -522,4 +525,27 @@ export function parsePhotoDb(mountpoint: string): NativePhotoDatabase {
 export function createPhotoDb(mountpoint?: string): NativePhotoDatabase {
   const binding = loadBinding();
   return binding.createPhotoDb(mountpoint);
+}
+
+/**
+ * Read SysInfoExtended XML from an iPod via USB vendor control transfer.
+ *
+ * This is a standalone function that does not require an open database.
+ * It communicates directly with the iPod's USB interface to retrieve
+ * the SysInfoExtended XML, which contains detailed device identification
+ * data (model, serial, firmware version, etc.).
+ *
+ * Requires libusb. The bus number and device address identify the USB
+ * device (obtainable from system_profiler on macOS or sysfs on Linux).
+ *
+ * @param busNumber USB bus number
+ * @param deviceAddress USB device address
+ * @returns XML string or null if the read fails
+ */
+export function readSysInfoExtendedFromUsb(
+  busNumber: number,
+  deviceAddress: number
+): string | null {
+  const binding = loadBinding();
+  return binding.readSysInfoExtendedFromUsb(busNumber, deviceAddress);
 }

--- a/packages/libgpod-node/src/index.ts
+++ b/packages/libgpod-node/src/index.ts
@@ -131,3 +131,6 @@ export {
 
 // Native binding utilities (for advanced use)
 export { isNativeAvailable, getVersion as getNativeVersion } from './binding';
+
+// USB functions
+export { readSysInfoExtendedFromUsb } from './binding';

--- a/packages/podkit-cli/src/commands/device.ts
+++ b/packages/podkit-cli/src/commands/device.ts
@@ -72,7 +72,11 @@ import {
   formatValidationMessages,
   DEFAULT_LOSSY_STACK,
   DEFAULT_LOSSLESS_STACK,
+  readSysInfoExtended,
+  ensureSysInfoExtended,
+  resolveUsbDeviceFromPath,
 } from '@podkit/core';
+import type { SysInfoExtendedResult } from '@podkit/core';
 import {
   openDevice,
   isMassStorageDevice,
@@ -92,6 +96,52 @@ import type { ReadinessResult, ReadinessStageResult, ReadinessLevel } from '@pod
 // Re-export formatting utilities for backward compatibility
 export { formatBytes, formatNumber } from '../output/index.js';
 export { formatGeneration } from '@podkit/core';
+
+/**
+ * Attempt to read or obtain SysInfoExtended for an iPod.
+ *
+ * Returns the result if SysInfoExtended is present (existing or freshly read
+ * from USB), or null if unavailable. Never throws — USB read failures are
+ * logged at verbose/debug level and do not block the caller.
+ */
+async function attemptSysInfoExtended(
+  mountPoint: string,
+  out: OutputContext
+): Promise<SysInfoExtendedResult | null> {
+  try {
+    // 1. Check for existing SysInfoExtended on disk
+    const existing = readSysInfoExtended(mountPoint);
+    if (existing?.present && existing.deviceInfo) {
+      return existing;
+    }
+
+    // 2. Try to resolve USB device info from mount path
+    const usbInfo = await resolveUsbDeviceFromPath(mountPoint);
+    if (!usbInfo?.busNumber || !usbInfo?.deviceAddress) {
+      out.verbose1('Could not resolve USB device for SysInfoExtended read');
+      return null;
+    }
+
+    // 3. Attempt USB read via orchestrator
+    const result = await ensureSysInfoExtended(mountPoint, {
+      busNumber: usbInfo.busNumber,
+      deviceAddress: usbInfo.deviceAddress,
+    });
+
+    if (result.present && result.source === 'usb-read') {
+      const model = result.deviceInfo?.modelName ?? 'Unknown iPod';
+      out.print(`Device identified via USB: ${model}`);
+    } else if (!result.present) {
+      out.verbose1(`SysInfoExtended read failed: ${result.error ?? 'unknown error'}`);
+    }
+
+    return result.present ? result : null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    out.verbose1(`SysInfoExtended attempt failed: ${message}`);
+    return null;
+  }
+}
 
 /**
  * Get storage information for a mount point.
@@ -1571,6 +1621,9 @@ const addSubcommand = new Command('add')
         return;
       }
 
+      // Attempt SysInfoExtended read (before database init so it's available for checksums)
+      const sysInfoResult = await attemptSysInfoExtended(explicitPath, out);
+
       // Check if database exists
       const hasDb = await IpodDatabase.hasDatabase(explicitPath);
       let trackCount = 0;
@@ -1619,6 +1672,11 @@ const addSubcommand = new Command('add')
           const message = err instanceof Error ? err.message : String(err);
           out.verbose1(`Warning: Could not read database: ${message}`);
         }
+      }
+
+      // Enrich model name from SysInfoExtended if available (more specific than database model)
+      if (sysInfoResult?.deviceInfo?.modelName) {
+        modelName = sysInfoResult.deviceInfo.modelName;
       }
 
       // Get volume UUID if possible (for macOS)
@@ -1894,6 +1952,12 @@ const addSubcommand = new Command('add')
       }
     }
 
+    // Attempt SysInfoExtended read (before database init so it's available for checksums)
+    let autoSysInfoResult: SysInfoExtendedResult | null = null;
+    if (ipod.mountPoint) {
+      autoSysInfoResult = await attemptSysInfoExtended(ipod.mountPoint, out);
+    }
+
     // Check if the iPod has a database
     let trackCount = 0;
     let modelName = 'Unknown';
@@ -1944,6 +2008,11 @@ const addSubcommand = new Command('add')
           // Couldn't read database info, continue anyway
         }
       }
+    }
+
+    // Enrich model name from SysInfoExtended if available (more specific than database model)
+    if (autoSysInfoResult?.deviceInfo?.modelName) {
+      modelName = autoSysInfoResult.deviceInfo.modelName;
     }
 
     const deviceInfo = {

--- a/packages/podkit-cli/src/commands/device.ts
+++ b/packages/podkit-cli/src/commands/device.ts
@@ -19,6 +19,7 @@
  * podkit device init [-d name]        # initialize iPod database
  * ```
  */
+import { join } from 'node:path';
 import { Command, Option } from 'commander';
 import { confirm, confirmNo } from '../utils/confirm.js';
 import { existsSync, statSync, statfsSync } from '../utils/fs.js';
@@ -98,48 +99,94 @@ export { formatBytes, formatNumber } from '../output/index.js';
 export { formatGeneration } from '@podkit/core';
 
 /**
- * Attempt to read or obtain SysInfoExtended for an iPod.
+ * Outcome of attempting to ensure the iPod has identity data.
  *
- * Returns the result if SysInfoExtended is present (existing or freshly read
- * from USB), or null if unavailable. Never throws — USB read failures are
- * logged at verbose/debug level and do not block the caller.
+ * - `result`: parsed SysInfoExtended (existing or freshly read), or null if
+ *   the device only has classic SysInfo and we didn't need to write anything.
+ * - `abort`: true if the device-add flow should stop. Set when the iPod has
+ *   no identity files, USB is unreachable or the user declined the prompt.
+ *   Caller is responsible for printing nothing further and returning early.
+ */
+interface SysInfoAttempt {
+  result: SysInfoExtendedResult | null;
+  abort: boolean;
+}
+
+/**
+ * Ensure an iPod has at least one identity file (SysInfo or SysInfoExtended).
+ *
+ * Skip path: if either file already exists, return without touching the
+ * device — classic SysInfo alone is sufficient for podkit.
+ *
+ * Gate path: if neither file is present, prompt the user (default no) before
+ * reading SysInfoExtended from USB firmware and writing it to the device.
+ * `--yes` and JSON output bypass the prompt. If the user declines or USB
+ * cannot be reached, signal abort so the caller stops the device-add flow.
  */
 async function attemptSysInfoExtended(
   mountPoint: string,
-  out: OutputContext
-): Promise<SysInfoExtendedResult | null> {
+  out: OutputContext,
+  opts: { autoConfirm: boolean }
+): Promise<SysInfoAttempt> {
+  // 1. SysInfoExtended already present and parseable → done.
+  const existing = readSysInfoExtended(mountPoint);
+  if (existing?.present && existing.deviceInfo) {
+    return { result: existing, abort: false };
+  }
+
+  // 2. Classic SysInfo present → also sufficient. Skip silently.
+  const sysInfoPath = join(mountPoint, 'iPod_Control', 'Device', 'SysInfo');
+  if (existsSync(sysInfoPath)) {
+    return { result: null, abort: false };
+  }
+
+  // 3. Neither file present. Resolve USB before prompting — without it we
+  //    can't perform the read. If USB is unreachable (e.g. --path fixture,
+  //    offline reattach), silently skip: the downstream init step will
+  //    create classic SysInfo if the database is also missing.
+  const usbInfo = await resolveUsbDeviceFromPath(mountPoint);
+  if (!usbInfo?.busNumber || !usbInfo?.deviceAddress) {
+    out.verbose1('No SysInfo or SysInfoExtended on device, and USB device could not be located.');
+    return { result: null, abort: false };
+  }
+
+  // 4. Prompt the user.
+  const skipPrompt = opts.autoConfirm || out.isJson;
+  if (!skipPrompt) {
+    out.newline();
+    out.print('This iPod has no identity files (SysInfo / SysInfoExtended).');
+    out.print("podkit needs one to recognize the device's model, serial, and FireWireGUID.");
+    out.print(
+      'It will read this from the iPod firmware via USB and save\n' +
+        'iPod_Control/Device/SysInfoExtended to the device.'
+    );
+    out.newline();
+    const proceed = await confirmNo('Continue?');
+    if (!proceed) {
+      out.print('Cancelled. Device not added.');
+      return { result: null, abort: true };
+    }
+  }
+
+  // 5. Read from USB and write the file.
   try {
-    // 1. Check for existing SysInfoExtended on disk
-    const existing = readSysInfoExtended(mountPoint);
-    if (existing?.present && existing.deviceInfo) {
-      return existing;
-    }
-
-    // 2. Try to resolve USB device info from mount path
-    const usbInfo = await resolveUsbDeviceFromPath(mountPoint);
-    if (!usbInfo?.busNumber || !usbInfo?.deviceAddress) {
-      out.verbose1('Could not resolve USB device for SysInfoExtended read');
-      return null;
-    }
-
-    // 3. Attempt USB read via orchestrator
     const result = await ensureSysInfoExtended(mountPoint, {
       busNumber: usbInfo.busNumber,
       deviceAddress: usbInfo.deviceAddress,
     });
 
-    if (result.present && result.source === 'usb-read') {
-      const model = result.deviceInfo?.modelName ?? 'Unknown iPod';
-      out.print(`Device identified via USB: ${model}`);
-    } else if (!result.present) {
-      out.verbose1(`SysInfoExtended read failed: ${result.error ?? 'unknown error'}`);
+    if (!result.present) {
+      out.error(`Failed to read SysInfoExtended from USB: ${result.error ?? 'unknown error'}`);
+      return { result: null, abort: true };
     }
 
-    return result.present ? result : null;
+    const model = result.deviceInfo?.modelName ?? 'Unknown iPod';
+    out.print(`Device identified via USB: ${model}`);
+    return { result, abort: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    out.verbose1(`SysInfoExtended attempt failed: ${message}`);
-    return null;
+    out.error(`SysInfoExtended read failed: ${message}`);
+    return { result: null, abort: true };
   }
 }
 
@@ -1622,7 +1669,12 @@ const addSubcommand = new Command('add')
       }
 
       // Attempt SysInfoExtended read (before database init so it's available for checksums)
-      const sysInfoResult = await attemptSysInfoExtended(explicitPath, out);
+      const sysInfoAttempt = await attemptSysInfoExtended(explicitPath, out, { autoConfirm });
+      if (sysInfoAttempt.abort) {
+        process.exitCode = 1;
+        return;
+      }
+      const sysInfoResult = sysInfoAttempt.result;
 
       // Check if database exists
       const hasDb = await IpodDatabase.hasDatabase(explicitPath);
@@ -1955,7 +2007,12 @@ const addSubcommand = new Command('add')
     // Attempt SysInfoExtended read (before database init so it's available for checksums)
     let autoSysInfoResult: SysInfoExtendedResult | null = null;
     if (ipod.mountPoint) {
-      autoSysInfoResult = await attemptSysInfoExtended(ipod.mountPoint, out);
+      const attempt = await attemptSysInfoExtended(ipod.mountPoint, out, { autoConfirm });
+      if (attempt.abort) {
+        process.exitCode = 1;
+        return;
+      }
+      autoSysInfoResult = attempt.result;
     }
 
     // Check if the iPod has a database

--- a/packages/podkit-cli/src/commands/device.ts
+++ b/packages/podkit-cli/src/commands/device.ts
@@ -19,6 +19,7 @@
  * podkit device init [-d name]        # initialize iPod database
  * ```
  */
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Command, Option } from 'commander';
 import { confirm, confirmNo } from '../utils/confirm.js';
@@ -76,6 +77,7 @@ import {
   readSysInfoExtended,
   ensureSysInfoExtended,
   resolveUsbDeviceFromPath,
+  getChecksumTypeByModelNumber,
 } from '@podkit/core';
 import type { SysInfoExtendedResult } from '@podkit/core';
 import {
@@ -113,10 +115,14 @@ interface SysInfoAttempt {
 }
 
 /**
- * Ensure an iPod has at least one identity file (SysInfo or SysInfoExtended).
+ * Ensure an iPod has SysInfoExtended when required, or at least SysInfo.
  *
- * Skip path: if either file already exists, return without touching the
- * device — classic SysInfo alone is sufficient for podkit.
+ * Skip path: if SysInfoExtended already exists, return it. If only SysInfo
+ * exists and the device doesn't require checksums, that's sufficient.
+ *
+ * Upgrade path: if only SysInfo exists but the device requires checksums
+ * (hash58+), SysInfoExtended is mandatory — prompt the user to read it
+ * from USB firmware.
  *
  * Gate path: if neither file is present, prompt the user (default no) before
  * reading SysInfoExtended from USB firmware and writing it to the device.
@@ -134,10 +140,69 @@ async function attemptSysInfoExtended(
     return { result: existing, abort: false };
   }
 
-  // 2. Classic SysInfo present → also sufficient. Skip silently.
+  // 2. Classic SysInfo present — check if SysInfoExtended is needed.
   const sysInfoPath = join(mountPoint, 'iPod_Control', 'Device', 'SysInfo');
   if (existsSync(sysInfoPath)) {
-    return { result: null, abort: false };
+    // Read the ModelNumStr to determine if this device needs checksums
+    let needsChecksum = false;
+    let modelNumber: string | undefined;
+    try {
+      const content = readFileSync(sysInfoPath, 'utf-8');
+      const match = content.match(/ModelNumStr:\s*(\S+)/);
+      if (match?.[1]) {
+        modelNumber = match[1];
+        const checksumType = getChecksumTypeByModelNumber(modelNumber);
+        needsChecksum =
+          checksumType === 'hash58' || checksumType === 'hash72' || checksumType === 'hashAB';
+      }
+    } catch {
+      // Can't read SysInfo — fall through to USB read
+    }
+
+    if (!needsChecksum) {
+      // Non-checksum device: SysInfo alone is sufficient.
+      return { result: null, abort: false };
+    }
+
+    // Checksum device with only SysInfo — SysInfoExtended is required.
+    // Try to read it from USB.
+    const usbInfo = await resolveUsbDeviceFromPath(mountPoint);
+    if (!usbInfo?.busNumber || !usbInfo?.deviceAddress) {
+      out.newline();
+      out.print(
+        `Warning: This iPod (${modelNumber ?? 'unknown model'}) requires SysInfoExtended for database checksums,` +
+          ' but USB device could not be located to read it.'
+      );
+      out.print(
+        '  Run `podkit doctor --repair sysinfo-extended` when the device is connected via USB.'
+      );
+      return { result: null, abort: false };
+    }
+
+    const skipPrompt = opts.autoConfirm || out.isJson;
+    if (!skipPrompt) {
+      out.newline();
+      out.print(
+        `This iPod (${modelNumber ?? 'unknown'}) requires SysInfoExtended for database checksums.`
+      );
+      out.print('Without it, the iPod will reject the database and show "No Music" after syncing.');
+      out.print(
+        'podkit can read this from the iPod firmware via USB and save\n' +
+          'iPod_Control/Device/SysInfoExtended to the device.'
+      );
+      out.newline();
+      const proceed = await confirmNo('Read SysInfoExtended from USB?');
+      if (!proceed) {
+        out.print('Skipped. You can run `podkit doctor --repair sysinfo-extended` later.');
+        return { result: null, abort: false };
+      }
+    }
+
+    return readSysInfoExtendedFromUsb(
+      mountPoint,
+      { busNumber: usbInfo.busNumber!, deviceAddress: usbInfo.deviceAddress! },
+      out
+    );
   }
 
   // 3. Neither file present. Resolve USB before prompting — without it we
@@ -169,6 +234,19 @@ async function attemptSysInfoExtended(
   }
 
   // 5. Read from USB and write the file.
+  return readSysInfoExtendedFromUsb(
+    mountPoint,
+    { busNumber: usbInfo.busNumber, deviceAddress: usbInfo.deviceAddress },
+    out
+  );
+}
+
+/** Shared helper: read SysInfoExtended from USB and write to device. */
+async function readSysInfoExtendedFromUsb(
+  mountPoint: string,
+  usbInfo: { busNumber: number; deviceAddress: number },
+  out: OutputContext
+): Promise<SysInfoAttempt> {
   try {
     const result = await ensureSysInfoExtended(mountPoint, {
       busNumber: usbInfo.busNumber,
@@ -779,12 +857,18 @@ function printReadinessStages(
       out.print(`    ${stage.summary}`);
     }
 
-    // Always surface SysInfoExtended presence under the sysinfo stage so
-    // users don't have to infer it from the model summary.
+    // Surface SysInfoExtended status under the sysinfo stage. For checksum
+    // devices, absence is a problem — make that clear.
     if (stage.stage === 'sysinfo' && stage.status !== 'skip') {
       const present = stage.details?.sysInfoExtendedExists;
+      const checksumType = stage.details?.checksumType as string | undefined;
+      const needsChecksum =
+        checksumType === 'hash58' || checksumType === 'hash72' || checksumType === 'hashAB';
       if (present === true) {
         out.print('    SysInfoExtended: present');
+      } else if (present === false && needsChecksum) {
+        out.print('    SysInfoExtended: missing (required for database checksums)');
+        out.print('    Run `podkit doctor --repair sysinfo-extended` to fix');
       } else if (present === false) {
         out.print('    SysInfoExtended: not present');
       }

--- a/packages/podkit-cli/src/commands/device.ts
+++ b/packages/podkit-cli/src/commands/device.ts
@@ -773,8 +773,21 @@ function printReadinessStages(
       stage.stage !== 'filesystem'
     ) {
       out.print(`    ${stage.summary}`);
+    } else if (stage.status === 'warn') {
+      out.print(`    ${stage.summary}`);
     } else if (stage.status === 'skip') {
       out.print(`    ${stage.summary}`);
+    }
+
+    // Always surface SysInfoExtended presence under the sysinfo stage so
+    // users don't have to infer it from the model summary.
+    if (stage.stage === 'sysinfo' && stage.status !== 'skip') {
+      const present = stage.details?.sysInfoExtendedExists;
+      if (present === true) {
+        out.print('    SysInfoExtended: present');
+      } else if (present === false) {
+        out.print('    SysInfoExtended: not present');
+      }
     }
   }
 

--- a/packages/podkit-cli/src/commands/doctor.ts
+++ b/packages/podkit-cli/src/commands/doctor.ts
@@ -330,12 +330,17 @@ function printReadinessStages(out: OutputContext, stages: ReadinessStageResult[]
       out.print(`    ${stage.summary}`);
     }
 
-    // Always surface SysInfoExtended presence under the sysinfo stage so
-    // users don't have to infer it from the model summary.
+    // Surface SysInfoExtended status under the sysinfo stage. For checksum
+    // devices, absence is a problem — make that clear.
     if (stage.stage === 'sysinfo' && stage.status !== 'skip') {
       const present = stage.details?.sysInfoExtendedExists;
+      const checksumType = stage.details?.checksumType as string | undefined;
+      const needsChecksum =
+        checksumType === 'hash58' || checksumType === 'hash72' || checksumType === 'hashAB';
       if (present === true) {
         out.print('    SysInfoExtended: present');
+      } else if (present === false && needsChecksum) {
+        out.print('    SysInfoExtended: missing (required for database checksums)');
       } else if (present === false) {
         out.print('    SysInfoExtended: not present');
       }

--- a/packages/podkit-cli/src/commands/doctor.ts
+++ b/packages/podkit-cli/src/commands/doctor.ts
@@ -324,8 +324,21 @@ function printReadinessStages(out: OutputContext, stages: ReadinessStageResult[]
       stage.stage !== 'filesystem'
     ) {
       out.print(`    ${stage.summary}`);
+    } else if (stage.status === 'warn') {
+      out.print(`    ${stage.summary}`);
     } else if (stage.status === 'skip') {
       out.print(`    ${stage.summary}`);
+    }
+
+    // Always surface SysInfoExtended presence under the sysinfo stage so
+    // users don't have to infer it from the model summary.
+    if (stage.stage === 'sysinfo' && stage.status !== 'skip') {
+      const present = stage.details?.sysInfoExtendedExists;
+      if (present === true) {
+        out.print('    SysInfoExtended: present');
+      } else if (present === false) {
+        out.print('    SysInfoExtended: not present');
+      }
     }
   }
 }

--- a/packages/podkit-cli/src/commands/doctor.ts
+++ b/packages/podkit-cli/src/commands/doctor.ts
@@ -156,11 +156,14 @@ async function resolveDevice(
 export const doctorCommand = new Command('doctor')
   .description('run health checks on a device')
   .addOption(
+    // Note: this list must be kept in sync with diagnostic checks registered
+    // in packages/podkit-core/src/diagnostics/index.ts (getDiagnosticCheckIds)
     new Option('--repair <check-id>', 'repair a specific check by ID').choices([
       'artwork-rebuild',
       'artwork-reset',
       'orphan-files',
       'orphan-files-mass-storage',
+      'sysinfo-extended',
     ])
   )
   .option('-c, --collection <name>', 'music collection to use as artwork source')

--- a/packages/podkit-cli/src/commands/doctor.ts
+++ b/packages/podkit-cli/src/commands/doctor.ts
@@ -83,6 +83,35 @@ interface DoctorOptions {
   format?: 'csv';
 }
 
+// ── Suggested actions ────────────────────────────────────────────────────────
+
+interface SuggestedAction {
+  /** Why the user might want to run this — printed as a section heading. */
+  reason: string;
+  /** Exact command to run, including the user's `-d` argument. */
+  command: string;
+}
+
+/**
+ * Quote a CLI argument so users can copy-paste the action verbatim. Returns
+ * an unquoted token when the value has no whitespace or shell metacharacters,
+ * otherwise wraps it in double quotes with embedded `"` and `\` escaped.
+ */
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+,=-]+$/.test(value)) return value;
+  return `"${value.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function printSuggestedActions(out: OutputContext, actions: SuggestedAction[]): void {
+  if (actions.length === 0) return;
+  out.newline();
+  out.print('Suggested actions:');
+  for (const action of actions) {
+    out.print(`  ${action.reason}:`);
+    out.print(`    ${action.command}`);
+  }
+}
+
 // ── Status symbols ──────────────────────────────────────────────────────────
 
 function statusSymbol(status: string): string {
@@ -318,7 +347,7 @@ async function runDoctorDiagnostics(
     return;
   }
 
-  const { config } = getContext();
+  const { config, globalOpts } = getContext();
   const isMassStorage = deviceConfig?.type !== undefined && deviceConfig.type !== 'ipod';
 
   // Mass-storage devices: resolve content paths and run applicable checks
@@ -371,15 +400,6 @@ async function runDoctorDiagnostics(
 
           const sym = statusSymbol(check.status);
           out.print(`  ${sym} ${check.name}    ${check.summary}`);
-
-          // Show repair instructions if repairable
-          if (check.repairable) {
-            const diagCheck = getDiagnosticCheck(check.id);
-            if (diagCheck?.repair) {
-              out.newline();
-              out.print(`    To repair: podkit doctor --repair ${check.id}`);
-            }
-          }
         }
       }
 
@@ -393,6 +413,20 @@ async function runDoctorDiagnostics(
         ).length;
         out.error(`${issueCount || 1} issue${issueCount === 1 ? '' : 's'} found.`);
       }
+
+      const msDeviceArg = shellQuote(globalOpts.device ?? devicePath);
+      const msActions: SuggestedAction[] = [];
+      for (const check of report.checks) {
+        if (!check.repairable || check.repairOnly) continue;
+        if (check.status !== 'fail' && check.status !== 'warn') continue;
+        const diagCheck = getDiagnosticCheck(check.id);
+        if (!diagCheck?.repair) continue;
+        msActions.push({
+          reason: check.name,
+          command: `podkit doctor --repair ${check.id} -d ${msDeviceArg}`,
+        });
+      }
+      printSuggestedActions(out, msActions);
     });
 
     if (!report.healthy) {
@@ -530,6 +564,50 @@ async function runDoctorDiagnostics(
 
   const getDiagnosticCheck = core.getDiagnosticCheck;
 
+  // Echo back the device argument the user typed (config name or path)
+  // so action commands are copy-pasteable verbatim.
+  const deviceArg = shellQuote(globalOpts.device ?? devicePath);
+
+  // Collect actions across readiness + DB checks; rendered as a single
+  // section after the issue summary.
+  const actions: SuggestedAction[] = [];
+  if (readinessResult) {
+    for (const stage of readinessResult.stages) {
+      if (stage.stage === 'sysinfo' && (stage.status === 'fail' || stage.status === 'warn')) {
+        actions.push({
+          reason: 'Create SysInfoExtended from USB device information',
+          command: `podkit doctor --repair sysinfo-extended -d ${deviceArg}`,
+        });
+      }
+      if (stage.stage === 'database' && stage.status === 'fail') {
+        actions.push({
+          reason: 'Initialize the iPod database',
+          command: `podkit device init -d ${deviceArg}`,
+        });
+      }
+    }
+  }
+  if (report) {
+    for (const check of report.checks) {
+      if (!check.repairable || check.repairOnly || check.scope === 'system') continue;
+      if (check.status !== 'fail' && check.status !== 'warn') continue;
+      const diagCheck = getDiagnosticCheck(check.id);
+      if (!diagCheck?.repair) continue;
+      const needsCollection = diagCheck.repair.requirements.includes('source-collection');
+      const colArg = needsCollection ? ' -c <collection>' : '';
+      actions.push({
+        reason: check.name,
+        command: `podkit doctor --repair ${check.id} -d ${deviceArg}${colArg}`,
+      });
+      if (check.id === 'artwork-rebuild') {
+        actions.push({
+          reason: 'Or clear all artwork (no source needed)',
+          command: `podkit doctor --repair artwork-reset -d ${deviceArg}`,
+        });
+      }
+    }
+  }
+
   out.result<DoctorOutput>(output, () => {
     out.print(`podkit doctor \u2014 checking iPod at ${devicePath}`);
 
@@ -606,27 +684,6 @@ async function runDoctorDiagnostics(
           printOrphanSummary(check.details as Record<string, unknown>, out);
         }
 
-        // Show repair instructions if the check is repairable
-        if (check.repairable) {
-          const diagCheck = getDiagnosticCheck(check.id);
-          if (diagCheck?.repair) {
-            out.newline();
-            const reqHints: string[] = [];
-            if (diagCheck.repair.requirements.includes('source-collection')) {
-              reqHints.push('-c <collection>');
-            }
-            const reqStr = reqHints.length > 0 ? ` ${reqHints.join(' ')}` : '';
-            out.print(`    To repair: podkit doctor --repair ${check.id}${reqStr}`);
-
-            // For artwork-rebuild, offer the reset alternative (no source needed)
-            if (check.id === 'artwork-rebuild') {
-              out.print(
-                `    Or clear all artwork (no source needed): podkit doctor --repair artwork-reset`
-              );
-            }
-          }
-        }
-
         if (check.docsUrl) {
           out.print(`    More info: ${check.docsUrl}`);
         }
@@ -650,6 +707,8 @@ async function runDoctorDiagnostics(
       if (issueCount === 0) issueCount = 1;
       out.error(`${issueCount} issue${issueCount === 1 ? '' : 's'} found.`);
     }
+
+    printSuggestedActions(out, actions);
   });
 
   opened?.ipod?.close();

--- a/packages/podkit-core/src/device/assessment.ts
+++ b/packages/podkit-core/src/device/assessment.ts
@@ -46,6 +46,12 @@ export interface UsbDeviceInfo {
   vendorId: string;
   /** Resolved human-readable model name if the product ID is known */
   modelName?: string;
+  /** USB serial number (= FirewireGuid for iPods, 16 hex chars) */
+  serialNumber?: string;
+  /** USB bus number (for libusb device addressing) */
+  busNumber?: number;
+  /** USB device address (for libusb device addressing) */
+  deviceAddress?: number;
 }
 
 /**

--- a/packages/podkit-core/src/device/index.ts
+++ b/packages/podkit-core/src/device/index.ts
@@ -93,7 +93,20 @@ export type {
 } from './assessment.js';
 
 export { detectIFlash } from './assessment.js';
-export { lookupIpodModel } from './ipod-models.js';
+export {
+  lookupIpodModel,
+  lookupIpodModelByNumber,
+  lookupIpodModelBySerial,
+  lookupGenerationByProductId,
+  getGenerationInfo,
+  getChecksumType,
+} from './ipod-models.js';
+export type {
+  IpodChecksumType,
+  IpodGenerationId,
+  IpodGeneration,
+  IpodModelVariant,
+} from './ipod-models.js';
 
 // Readiness pipeline
 export type {
@@ -114,7 +127,7 @@ export {
 
 // USB discovery
 export type { UsbDiscoveredDevice } from './usb-discovery.js';
-export { discoverUsbIpods } from './usb-discovery.js';
+export { discoverUsbIpods, resolveUsbDeviceFromPath } from './usb-discovery.js';
 
 // OS error code interpreter
 export type { InterpretedError } from './error-codes.js';

--- a/packages/podkit-core/src/device/index.ts
+++ b/packages/podkit-core/src/device/index.ts
@@ -125,6 +125,10 @@ export {
   STAGE_DISPLAY_NAMES,
 } from './readiness.js';
 
+// SysInfoExtended orchestrator
+export type { SysInfoExtendedResult, UsbDeviceAddress, ReadFromUsbFn } from './sysinfo-extended.js';
+export { ensureSysInfoExtended, readSysInfoExtended } from './sysinfo-extended.js';
+
 // USB discovery
 export type { UsbDiscoveredDevice } from './usb-discovery.js';
 export { discoverUsbIpods, resolveUsbDeviceFromPath } from './usb-discovery.js';

--- a/packages/podkit-core/src/device/index.ts
+++ b/packages/podkit-core/src/device/index.ts
@@ -100,6 +100,7 @@ export {
   lookupGenerationByProductId,
   getGenerationInfo,
   getChecksumType,
+  getChecksumTypeByModelNumber,
 } from './ipod-models.js';
 export type {
   IpodChecksumType,

--- a/packages/podkit-core/src/device/ipod-models.test.ts
+++ b/packages/podkit-core/src/device/ipod-models.test.ts
@@ -1,0 +1,367 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getChecksumType,
+  getGenerationInfo,
+  lookupGenerationByProductId,
+  lookupIpodModel,
+  lookupIpodModelByNumber,
+  lookupIpodModelBySerial,
+} from './ipod-models.js';
+
+import type { IpodChecksumType, IpodGenerationId } from './ipod-models.js';
+
+// ── Backward compatibility: lookupIpodModel ─────────────────────────────────
+
+describe('lookupIpodModel', () => {
+  test('returns model name for known 0x120x product IDs', () => {
+    expect(lookupIpodModel('0x1209')).toBe('iPod Classic 6th generation');
+    expect(lookupIpodModel('0x120a')).toBe('iPod Classic 7th generation');
+    expect(lookupIpodModel('0x1207')).toBe('iPod 5th generation (Video)');
+    expect(lookupIpodModel('0x1205')).toBe('iPod nano 1st generation');
+    expect(lookupIpodModel('0x1208')).toBe('iPod nano 3rd generation');
+    expect(lookupIpodModel('0x120b')).toBe('iPod nano 4th generation');
+    expect(lookupIpodModel('0x120c')).toBe('iPod nano 5th generation');
+    expect(lookupIpodModel('0x120d')).toBe('iPod nano 6th generation');
+    expect(lookupIpodModel('0x120e')).toBe('iPod nano 7th generation');
+  });
+
+  test('returns model name for new 0x126x product IDs', () => {
+    expect(lookupIpodModel('0x1260')).toBe('iPod nano 2nd generation');
+    expect(lookupIpodModel('0x1261')).toBe('iPod Classic 6th generation');
+    expect(lookupIpodModel('0x1262')).toBe('iPod nano 3rd generation');
+    expect(lookupIpodModel('0x1263')).toBe('iPod nano 4th generation');
+    expect(lookupIpodModel('0x1265')).toBe('iPod nano 5th generation');
+    expect(lookupIpodModel('0x1266')).toBe('iPod nano 6th generation');
+    expect(lookupIpodModel('0x1267')).toBe('iPod nano 7th generation');
+  });
+
+  test('returns model name for shuffle IDs', () => {
+    expect(lookupIpodModel('0x1300')).toBe('iPod shuffle 1st generation');
+    expect(lookupIpodModel('0x1301')).toBe('iPod shuffle 2nd generation');
+    expect(lookupIpodModel('0x1302')).toBe('iPod shuffle 3rd generation');
+    expect(lookupIpodModel('0x1303')).toBe('iPod shuffle 4th generation');
+  });
+
+  test('returns model name for touch IDs', () => {
+    expect(lookupIpodModel('0x1291')).toBe('iPod touch 1st generation');
+    expect(lookupIpodModel('0x129a')).toBe('iPod touch 4th generation');
+  });
+
+  test('returns model name for mini IDs', () => {
+    expect(lookupIpodModel('0x1202')).toBe('iPod mini 1st generation');
+    expect(lookupIpodModel('0x1204')).toBe('iPod mini 2nd generation');
+  });
+
+  test('normalises input without 0x prefix', () => {
+    expect(lookupIpodModel('1209')).toBe('iPod Classic 6th generation');
+    expect(lookupIpodModel('1262')).toBe('iPod nano 3rd generation');
+  });
+
+  test('normalises uppercase input', () => {
+    expect(lookupIpodModel('0X1209')).toBe('iPod Classic 6th generation');
+    expect(lookupIpodModel('0X1262')).toBe('iPod nano 3rd generation');
+  });
+
+  test('returns undefined for unknown product ID', () => {
+    expect(lookupIpodModel('0x9999')).toBeUndefined();
+  });
+
+  test('returns undefined for DFU/WTF mode IDs (excluded by design)', () => {
+    expect(lookupIpodModel('0x1223')).toBeUndefined();
+    expect(lookupIpodModel('0x1224')).toBeUndefined();
+  });
+});
+
+// ── Backward compatibility: lookupIpodModelByNumber ─────────────────────────
+
+describe('lookupIpodModelByNumber', () => {
+  test('returns display name for known model numbers with M prefix', () => {
+    expect(lookupIpodModelByNumber('MA147')).toBe('iPod Video 60GB Black (5th Generation)');
+    expect(lookupIpodModelByNumber('MC297')).toBe('iPod Classic 160GB Black (7th Generation)');
+    expect(lookupIpodModelByNumber('MB261')).toBe('iPod nano 8GB Black (3rd Generation)');
+  });
+
+  test('returns display name for known model numbers without M prefix', () => {
+    expect(lookupIpodModelByNumber('A147')).toBe('iPod Video 60GB Black (5th Generation)');
+    expect(lookupIpodModelByNumber('B261')).toBe('iPod nano 8GB Black (3rd Generation)');
+  });
+
+  test('is case-insensitive', () => {
+    expect(lookupIpodModelByNumber('ma147')).toBe('iPod Video 60GB Black (5th Generation)');
+    expect(lookupIpodModelByNumber('mb261')).toBe('iPod nano 8GB Black (3rd Generation)');
+  });
+
+  test('returns display name for legacy entries', () => {
+    // MA099LL was in the old table
+    expect(lookupIpodModelByNumber('MA099LL')).toBe('iPod nano 1GB (1st Generation)');
+    // MC477 was in the old table
+    expect(lookupIpodModelByNumber('MC477')).toBe('iPod Classic 160GB (7th Generation)');
+  });
+
+  test('returns undefined for unknown model numbers', () => {
+    expect(lookupIpodModelByNumber('MZZZZ')).toBeUndefined();
+    expect(lookupIpodModelByNumber('Z9999')).toBeUndefined();
+  });
+
+  test('handles all previously known model numbers from the old table', () => {
+    const oldTableEntries: [string, string][] = [
+      ['M8513', 'iPod 5GB (1st Generation)'],
+      ['M8737', 'iPod 10GB (2nd Generation)'],
+      ['M8976', 'iPod 10GB (3rd Generation)'],
+      ['M9282', 'iPod 20GB (4th Generation)'],
+      ['MA079', 'iPod Photo 20GB'],
+      ['MA002', 'iPod Video 30GB White (5th Generation)'],
+      ['MA444', 'iPod Video 30GB White (5.5th Generation)'],
+      ['MB029', 'iPod Classic 80GB Silver (6th Generation)'],
+      ['MC293', 'iPod Classic 160GB Silver (7th Generation)'],
+      ['M9160', 'iPod mini 4GB (1st Generation)'],
+      ['M9800', 'iPod mini 4GB (2nd Generation)'],
+      ['MA004', 'iPod nano 2GB White (1st Generation)'],
+      ['MA477', 'iPod nano 2GB Silver (2nd Generation)'],
+      ['MB261', 'iPod nano 8GB Black (3rd Generation)'],
+      ['MB598', 'iPod nano 8GB Silver (4th Generation)'],
+      ['MC027', 'iPod nano 8GB Silver (5th Generation)'],
+      ['MC525', 'iPod nano 8GB Silver (6th Generation)'],
+    ];
+
+    for (const [modelNum, _expectedName] of oldTableEntries) {
+      const result = lookupIpodModelByNumber(modelNum);
+      expect(result).toBeDefined();
+      // The new table may have enriched display names (e.g., added color).
+      // Just check that it returns something reasonable.
+      expect(typeof result).toBe('string');
+    }
+  });
+});
+
+// ── New: lookupIpodModelBySerial ────────────────────────────────────────────
+
+describe('lookupIpodModelBySerial', () => {
+  test('returns variant for known serial suffix (real hardware: nano 3G)', () => {
+    // Verified on real iPod Nano 3G: serial "5U8280FNYXX" -> suffix "YXX"
+    const variant = lookupIpodModelBySerial('YXX');
+    expect(variant).toBeDefined();
+    expect(variant!.modelNumber).toBe('B261');
+    expect(variant!.generation).toBe('nano_3g');
+    expect(variant!.capacityGb).toBe(8);
+    expect(variant!.color).toBe('Black');
+    expect(variant!.displayName).toBe('iPod nano 8GB Black (3rd Generation)');
+  });
+
+  test('returns variant for classic 6G suffix', () => {
+    const variant = lookupIpodModelBySerial('Y5N');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('classic_6g');
+    expect(variant!.modelNumber).toBe('B029');
+  });
+
+  test('returns variant for shuffle suffix', () => {
+    const variant = lookupIpodModelBySerial('RS9');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('shuffle_1g');
+  });
+
+  test('returns variant for nano 5G suffix', () => {
+    const variant = lookupIpodModelBySerial('71V');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('nano_5g');
+    expect(variant!.modelNumber).toBe('C027');
+  });
+
+  test('returns variant for nano 6G suffix', () => {
+    const variant = lookupIpodModelBySerial('CMN');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('nano_6g');
+    expect(variant!.modelNumber).toBe('C525');
+  });
+
+  test('returns variant for iPod touch suffix', () => {
+    const variant = lookupIpodModelBySerial('W4N');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('touch_1g');
+    expect(variant!.modelNumber).toBe('A623');
+  });
+
+  test('is case-insensitive', () => {
+    const upper = lookupIpodModelBySerial('YXX');
+    const lower = lookupIpodModelBySerial('yxx');
+    expect(upper).toEqual(lower);
+  });
+
+  test('returns undefined for unknown suffix', () => {
+    expect(lookupIpodModelBySerial('ZZZ')).toBeUndefined();
+  });
+
+  test('returns undefined for empty or wrong-length suffix', () => {
+    expect(lookupIpodModelBySerial('')).toBeUndefined();
+    expect(lookupIpodModelBySerial('AB')).toBeUndefined();
+    expect(lookupIpodModelBySerial('ABCD')).toBeUndefined();
+  });
+
+  test('returns variant for 1st gen iPod suffix', () => {
+    const variant = lookupIpodModelBySerial('LG6');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('classic_1g');
+  });
+
+  test('returns variant for iPod Photo suffix', () => {
+    const variant = lookupIpodModelBySerial('TDU');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('photo');
+    expect(variant!.modelNumber).toBe('A079');
+  });
+
+  test('returns variant for video 5.5G suffix', () => {
+    const variant = lookupIpodModelBySerial('V9K');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('video_5_5g');
+    expect(variant!.modelNumber).toBe('A444');
+  });
+});
+
+// ── New: getGenerationInfo ──────────────────────────────────────────────────
+
+describe('getGenerationInfo', () => {
+  test('returns correct info for classic_6g', () => {
+    const info = getGenerationInfo('classic_6g');
+    expect(info.id).toBe('classic_6g');
+    expect(info.displayName).toBe('iPod Classic (6th Generation)');
+    expect(info.checksumType).toBe('hash58');
+  });
+
+  test('returns correct info for nano_5g', () => {
+    const info = getGenerationInfo('nano_5g');
+    expect(info.id).toBe('nano_5g');
+    expect(info.checksumType).toBe('hash72');
+  });
+
+  test('returns correct info for nano_6g', () => {
+    const info = getGenerationInfo('nano_6g');
+    expect(info.checksumType).toBe('hashAB');
+  });
+
+  test('returns correct info for video_5g', () => {
+    const info = getGenerationInfo('video_5g');
+    expect(info.checksumType).toBe('none');
+  });
+});
+
+// ── New: getChecksumType ────────────────────────────────────────────────────
+
+describe('getChecksumType', () => {
+  test.each<[IpodGenerationId, IpodChecksumType]>([
+    // none -- early generations
+    ['classic_1g', 'none'],
+    ['classic_2g', 'none'],
+    ['classic_3g', 'none'],
+    ['classic_4g', 'none'],
+    ['photo', 'none'],
+    ['video_5g', 'none'],
+    ['video_5_5g', 'none'],
+    ['mini_1g', 'none'],
+    ['mini_2g', 'none'],
+    ['nano_1g', 'none'],
+    ['nano_2g', 'none'],
+    ['shuffle_1g', 'none'],
+    ['shuffle_2g', 'none'],
+
+    // hash58
+    ['classic_6g', 'hash58'],
+    ['classic_7g', 'hash58'],
+    ['nano_3g', 'hash58'],
+    ['nano_4g', 'hash58'],
+
+    // hash72
+    ['nano_5g', 'hash72'],
+
+    // hashAB
+    ['nano_6g', 'hashAB'],
+    ['touch_4g', 'hashAB'],
+
+    // none (unsupported but included for completeness)
+    ['shuffle_3g', 'none'],
+    ['shuffle_4g', 'none'],
+    ['touch_1g', 'none'],
+    ['touch_2g', 'none'],
+    ['touch_3g', 'none'],
+    ['touch_5g', 'none'],
+    ['touch_6g', 'none'],
+    ['touch_7g', 'none'],
+    ['nano_7g', 'none'],
+  ])('%s -> %s', (generation, expectedType) => {
+    expect(getChecksumType(generation)).toBe(expectedType);
+  });
+});
+
+// ── New: lookupGenerationByProductId ────────────────────────────────────────
+
+describe('lookupGenerationByProductId', () => {
+  test('returns generation for 0x120x range', () => {
+    expect(lookupGenerationByProductId('0x1209')).toBe('classic_6g');
+    expect(lookupGenerationByProductId('0x120a')).toBe('classic_7g');
+    expect(lookupGenerationByProductId('0x1208')).toBe('nano_3g');
+    expect(lookupGenerationByProductId('0x120b')).toBe('nano_4g');
+    expect(lookupGenerationByProductId('0x120c')).toBe('nano_5g');
+  });
+
+  test('returns generation for 0x126x range', () => {
+    expect(lookupGenerationByProductId('0x1261')).toBe('classic_6g');
+    expect(lookupGenerationByProductId('0x1262')).toBe('nano_3g');
+    expect(lookupGenerationByProductId('0x1263')).toBe('nano_4g');
+    expect(lookupGenerationByProductId('0x1265')).toBe('nano_5g');
+    expect(lookupGenerationByProductId('0x1266')).toBe('nano_6g');
+  });
+
+  test('both ranges map to the same generation', () => {
+    expect(lookupGenerationByProductId('0x1206')).toBe(lookupGenerationByProductId('0x1260'));
+    expect(lookupGenerationByProductId('0x1208')).toBe(lookupGenerationByProductId('0x1262'));
+    expect(lookupGenerationByProductId('0x120b')).toBe(lookupGenerationByProductId('0x1263'));
+    expect(lookupGenerationByProductId('0x120c')).toBe(lookupGenerationByProductId('0x1265'));
+  });
+
+  test('returns undefined for unknown product ID', () => {
+    expect(lookupGenerationByProductId('0x9999')).toBeUndefined();
+  });
+
+  test('normalises input without 0x prefix', () => {
+    expect(lookupGenerationByProductId('1209')).toBe('classic_6g');
+  });
+});
+
+// ── Cross-referencing: serial -> model -> generation -> checksum ─────────────
+
+describe('end-to-end identification pipeline', () => {
+  test('serial suffix -> model -> generation -> checksum type', () => {
+    // Real hardware: iPod Nano 3G, serial suffix YXX
+    const variant = lookupIpodModelBySerial('YXX');
+    expect(variant).toBeDefined();
+    expect(variant!.generation).toBe('nano_3g');
+
+    const checksumType = getChecksumType(variant!.generation);
+    expect(checksumType).toBe('hash58');
+
+    const genInfo = getGenerationInfo(variant!.generation);
+    expect(genInfo.displayName).toBe('iPod nano (3rd Generation)');
+  });
+
+  test('USB product ID -> generation -> checksum type', () => {
+    // 0x1262 = nano 3G (0x126x range)
+    const gen = lookupGenerationByProductId('0x1262');
+    expect(gen).toBe('nano_3g');
+
+    const checksumType = getChecksumType(gen!);
+    expect(checksumType).toBe('hash58');
+  });
+
+  test('model number -> serial suffix cross-reference', () => {
+    // lookupIpodModelByNumber("MB261") and lookupIpodModelBySerial("YXX")
+    // should both identify as nano 3G
+    const byNumber = lookupIpodModelByNumber('MB261');
+    const bySerial = lookupIpodModelBySerial('YXX');
+
+    expect(byNumber).toBeDefined();
+    expect(bySerial).toBeDefined();
+    expect(bySerial!.displayName).toBe(byNumber);
+  });
+});

--- a/packages/podkit-core/src/device/ipod-models.test.ts
+++ b/packages/podkit-core/src/device/ipod-models.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   getChecksumType,
+  getChecksumTypeByModelNumber,
   getGenerationInfo,
   lookupGenerationByProductId,
   lookupIpodModel,
@@ -370,5 +371,37 @@ describe('end-to-end identification pipeline', () => {
     expect(byNumber).toBeDefined();
     expect(bySerial).toBeDefined();
     expect(bySerial!.displayName).toBe(byNumber);
+  });
+});
+
+// ── getChecksumTypeByModelNumber ────────────────────────────────────────────
+
+describe('getChecksumTypeByModelNumber', () => {
+  test('returns none for iPod Video 5G (MA147)', () => {
+    expect(getChecksumTypeByModelNumber('MA147')).toBe('none');
+  });
+
+  test('returns hash58 for iPod Classic 6G (MB147)', () => {
+    expect(getChecksumTypeByModelNumber('MB147')).toBe('hash58');
+  });
+
+  test('returns hash58 for iPod Classic 7G (MC297)', () => {
+    expect(getChecksumTypeByModelNumber('MC297')).toBe('hash58');
+  });
+
+  test('returns hash58 for iPod Nano 3G (MB261)', () => {
+    expect(getChecksumTypeByModelNumber('MB261')).toBe('hash58');
+  });
+
+  test('returns none for iPod Nano 1G (MA350)', () => {
+    expect(getChecksumTypeByModelNumber('MA350')).toBe('none');
+  });
+
+  test('returns undefined for unrecognized model number', () => {
+    expect(getChecksumTypeByModelNumber('ZZZZ')).toBeUndefined();
+  });
+
+  test('handles lowercase model numbers', () => {
+    expect(getChecksumTypeByModelNumber('mb147')).toBe('hash58');
   });
 });

--- a/packages/podkit-core/src/device/ipod-models.test.ts
+++ b/packages/podkit-core/src/device/ipod-models.test.ts
@@ -87,6 +87,13 @@ describe('lookupIpodModelByNumber', () => {
     expect(lookupIpodModelByNumber('B261')).toBe('iPod nano 8GB Black (3rd Generation)');
   });
 
+  test('strips Apple service / refurb prefixes (P, F)', () => {
+    // P-prefix = service stock / replacement unit. Same hardware as M9804.
+    expect(lookupIpodModelByNumber('P9804')).toContain('iPod mini');
+    // F-prefix = factory refurbished. Same hardware as M9436.
+    expect(lookupIpodModelByNumber('F9436')).toContain('iPod mini');
+  });
+
   test('is case-insensitive', () => {
     expect(lookupIpodModelByNumber('ma147')).toBe('iPod Video 60GB Black (5th Generation)');
     expect(lookupIpodModelByNumber('mb261')).toBe('iPod nano 8GB Black (3rd Generation)');

--- a/packages/podkit-core/src/device/ipod-models.ts
+++ b/packages/podkit-core/src/device/ipod-models.ts
@@ -1,157 +1,1574 @@
 /**
- * Apple iPod USB product ID lookup table
+ * Unified iPod model registry.
  *
- * Maps Apple USB product IDs (vendor 0x05ac) to human-readable model names.
- * Based on community-maintained USB ID databases and direct device testing.
+ * Provides multiple access patterns for iPod device identification:
+ * - USB product ID -> generation + display name
+ * - SysInfo ModelNumStr -> display name + generation + capacity + color
+ * - Serial number suffix (last 3 chars) -> model variant
+ * - Generation -> checksum type required for iTunesDB
  *
- * Note: Apple has not published an official product ID list. Entries are
- * sourced from the Linux USB ID repository, libimobiledevice, and community
- * reports. Where sources conflict, the most commonly cited mapping is used.
+ * Sources:
+ * - USB product IDs: linux-usb.org usb.ids, community databases, direct hardware testing
+ * - Model numbers / serial suffixes: libgpod itdb_device.c (0.8.3), lines 633-868
+ * - Checksum types: libgpod hash implementation selection logic
+ *
+ * Note: This module duplicates some data from @podkit/ipod-db (packages/ipod-db/src/device/models.ts).
+ * The ipod-db package is the authoritative source for model capabilities (musicDirs, video support, etc.).
+ * This module focuses on device identification and checksum classification. A future consolidation
+ * (tracked in ipod-db) will unify these into a single source of truth.
  */
 
-const IPOD_MODELS: Record<string, string> = {
-  // -------------------------------------------------------------------------
-  // iPod Classic (hard disk / iFlash)
-  // -------------------------------------------------------------------------
-  '0x1207': 'iPod 5th generation (Video)',
-  '0x1209': 'iPod Classic 6th generation',
-  '0x120a': 'iPod Classic 7th generation',
+// ── Types ───────────────────────────────────────────────────────────────────
 
-  // -------------------------------------------------------------------------
-  // iPod mini
-  // -------------------------------------------------------------------------
-  '0x1202': 'iPod mini 1st generation',
-  '0x1204': 'iPod mini 2nd generation',
+/** Checksum type required for iPod database */
+export type IpodChecksumType = 'none' | 'hash58' | 'hash72' | 'hashAB';
 
-  // -------------------------------------------------------------------------
-  // iPod nano
-  // -------------------------------------------------------------------------
-  '0x1205': 'iPod nano 1st generation',
-  '0x1206': 'iPod nano 2nd generation',
-  '0x1208': 'iPod nano 3rd generation',
-  '0x120b': 'iPod nano 4th generation',
-  '0x120c': 'iPod nano 5th generation',
-  '0x120d': 'iPod nano 6th generation',
-  '0x120e': 'iPod nano 7th generation',
+/** iPod generation identifier */
+export type IpodGenerationId =
+  | 'classic_1g'
+  | 'classic_2g'
+  | 'classic_3g'
+  | 'classic_4g'
+  | 'photo'
+  | 'video_5g'
+  | 'video_5_5g'
+  | 'classic_6g'
+  | 'classic_7g'
+  | 'mini_1g'
+  | 'mini_2g'
+  | 'nano_1g'
+  | 'nano_2g'
+  | 'nano_3g'
+  | 'nano_4g'
+  | 'nano_5g'
+  | 'nano_6g'
+  | 'nano_7g'
+  | 'shuffle_1g'
+  | 'shuffle_2g'
+  | 'shuffle_3g'
+  | 'shuffle_4g'
+  | 'touch_1g'
+  | 'touch_2g'
+  | 'touch_3g'
+  | 'touch_4g'
+  | 'touch_5g'
+  | 'touch_6g'
+  | 'touch_7g';
 
-  // -------------------------------------------------------------------------
-  // iPod shuffle
-  // -------------------------------------------------------------------------
-  '0x1300': 'iPod shuffle 1st generation',
-  '0x1301': 'iPod shuffle 2nd generation',
-  '0x1302': 'iPod shuffle 3rd generation',
-  '0x1303': 'iPod shuffle 4th generation',
+/** Generation metadata */
+export interface IpodGeneration {
+  id: IpodGenerationId;
+  displayName: string;
+  checksumType: IpodChecksumType;
+}
 
-  // -------------------------------------------------------------------------
-  // iPod touch
-  // -------------------------------------------------------------------------
-  '0x1291': 'iPod touch 1st generation',
-  '0x1292': 'iPod touch 2nd generation',
-  '0x1293': 'iPod touch 3rd generation',
-  '0x129a': 'iPod touch 4th generation',
-  '0x12a0': 'iPod touch 5th generation',
-  '0x12ab': 'iPod touch 6th generation',
-  '0x12a8': 'iPod touch 7th generation',
+/** Model entry from serial suffix lookup -- specific variant (color, capacity) */
+export interface IpodModelVariant {
+  modelNumber: string; // e.g., "B261" (without M prefix)
+  displayName: string; // e.g., "iPod nano 8GB Black (3rd Generation)"
+  generation: IpodGenerationId;
+  capacityGb?: number;
+  color?: string;
+}
+
+// ── Generation definitions ──────────────────────────────────────────────────
+
+const GENERATIONS: Record<IpodGenerationId, IpodGeneration> = {
+  classic_1g: { id: 'classic_1g', displayName: 'iPod (1st Generation)', checksumType: 'none' },
+  classic_2g: { id: 'classic_2g', displayName: 'iPod (2nd Generation)', checksumType: 'none' },
+  classic_3g: { id: 'classic_3g', displayName: 'iPod (3rd Generation)', checksumType: 'none' },
+  classic_4g: { id: 'classic_4g', displayName: 'iPod (4th Generation)', checksumType: 'none' },
+  photo: { id: 'photo', displayName: 'iPod Photo', checksumType: 'none' },
+  video_5g: { id: 'video_5g', displayName: 'iPod Video (5th Generation)', checksumType: 'none' },
+  video_5_5g: {
+    id: 'video_5_5g',
+    displayName: 'iPod Video (5.5th Generation)',
+    checksumType: 'none',
+  },
+  classic_6g: {
+    id: 'classic_6g',
+    displayName: 'iPod Classic (6th Generation)',
+    checksumType: 'hash58',
+  },
+  classic_7g: {
+    id: 'classic_7g',
+    displayName: 'iPod Classic (7th Generation)',
+    checksumType: 'hash58',
+  },
+  mini_1g: { id: 'mini_1g', displayName: 'iPod mini (1st Generation)', checksumType: 'none' },
+  mini_2g: { id: 'mini_2g', displayName: 'iPod mini (2nd Generation)', checksumType: 'none' },
+  nano_1g: { id: 'nano_1g', displayName: 'iPod nano (1st Generation)', checksumType: 'none' },
+  nano_2g: { id: 'nano_2g', displayName: 'iPod nano (2nd Generation)', checksumType: 'none' },
+  nano_3g: { id: 'nano_3g', displayName: 'iPod nano (3rd Generation)', checksumType: 'hash58' },
+  nano_4g: { id: 'nano_4g', displayName: 'iPod nano (4th Generation)', checksumType: 'hash58' },
+  nano_5g: { id: 'nano_5g', displayName: 'iPod nano (5th Generation)', checksumType: 'hash72' },
+  nano_6g: { id: 'nano_6g', displayName: 'iPod nano (6th Generation)', checksumType: 'hashAB' },
+  nano_7g: { id: 'nano_7g', displayName: 'iPod nano (7th Generation)', checksumType: 'none' },
+  shuffle_1g: {
+    id: 'shuffle_1g',
+    displayName: 'iPod shuffle (1st Generation)',
+    checksumType: 'none',
+  },
+  shuffle_2g: {
+    id: 'shuffle_2g',
+    displayName: 'iPod shuffle (2nd Generation)',
+    checksumType: 'none',
+  },
+  shuffle_3g: {
+    id: 'shuffle_3g',
+    displayName: 'iPod shuffle (3rd Generation)',
+    checksumType: 'none',
+  },
+  shuffle_4g: {
+    id: 'shuffle_4g',
+    displayName: 'iPod shuffle (4th Generation)',
+    checksumType: 'none',
+  },
+  touch_1g: { id: 'touch_1g', displayName: 'iPod touch (1st Generation)', checksumType: 'none' },
+  touch_2g: { id: 'touch_2g', displayName: 'iPod touch (2nd Generation)', checksumType: 'none' },
+  touch_3g: { id: 'touch_3g', displayName: 'iPod touch (3rd Generation)', checksumType: 'none' },
+  touch_4g: { id: 'touch_4g', displayName: 'iPod touch (4th Generation)', checksumType: 'hashAB' },
+  touch_5g: { id: 'touch_5g', displayName: 'iPod touch (5th Generation)', checksumType: 'none' },
+  touch_6g: { id: 'touch_6g', displayName: 'iPod touch (6th Generation)', checksumType: 'none' },
+  touch_7g: { id: 'touch_7g', displayName: 'iPod touch (7th Generation)', checksumType: 'none' },
 };
+
+// ── USB product ID table ────────────────────────────────────────────────────
+//
+// Maps Apple USB product IDs (vendor 0x05ac) to generation identifiers.
+//
+// Two ID ranges exist for many models:
+// - 0x120x range: original community-catalogued IDs (USB ID repository, libimobiledevice)
+// - 0x126x range: confirmed by linux-usb.org and real hardware testing; appears on
+//   devices in disk mode or with newer firmware revisions.
+//
+// Both ranges map to the same generations. DFU/WTF mode IDs (0x1223, 0x1224, etc.)
+// are intentionally excluded -- those are recovery-mode endpoints, not disk-mode devices.
+//
+// Note: 0x1266 (nano 6g via 0x126x range) should be added to UNSUPPORTED_IPODS
+// in usb-discovery.ts (parallel task 279.02 is editing that file).
+
+interface UsbProductIdEntry {
+  generation: IpodGenerationId;
+  displayName: string;
+}
+
+const USB_PRODUCT_IDS: Record<string, UsbProductIdEntry> = {
+  // ── iPod Classic (hard disk / iFlash) ───────────────────────────────────
+  '0x1207': { generation: 'video_5g', displayName: 'iPod 5th generation (Video)' },
+  '0x1209': { generation: 'classic_6g', displayName: 'iPod Classic 6th generation' },
+  '0x120a': { generation: 'classic_7g', displayName: 'iPod Classic 7th generation' },
+
+  // ── iPod mini ───────────────────────────────────────────────────────────
+  '0x1202': { generation: 'mini_1g', displayName: 'iPod mini 1st generation' },
+  '0x1204': { generation: 'mini_2g', displayName: 'iPod mini 2nd generation' },
+
+  // ── iPod nano (0x120x range) ────────────────────────────────────────────
+  '0x1205': { generation: 'nano_1g', displayName: 'iPod nano 1st generation' },
+  '0x1206': { generation: 'nano_2g', displayName: 'iPod nano 2nd generation' },
+  '0x1208': { generation: 'nano_3g', displayName: 'iPod nano 3rd generation' },
+  '0x120b': { generation: 'nano_4g', displayName: 'iPod nano 4th generation' },
+  '0x120c': { generation: 'nano_5g', displayName: 'iPod nano 5th generation' },
+  '0x120d': { generation: 'nano_6g', displayName: 'iPod nano 6th generation' },
+  '0x120e': { generation: 'nano_7g', displayName: 'iPod nano 7th generation' },
+
+  // ── iPod nano (0x126x range) ────────────────────────────────────────────
+  // Source: linux-usb.org usb.ids + real hardware testing.
+  // These appear on devices in disk mode or with newer firmware revisions.
+  '0x1260': { generation: 'nano_2g', displayName: 'iPod nano 2nd generation' },
+  '0x1261': { generation: 'classic_6g', displayName: 'iPod Classic 6th generation' },
+  '0x1262': { generation: 'nano_3g', displayName: 'iPod nano 3rd generation' }, // confirmed on real iPod Nano 3G
+  '0x1263': { generation: 'nano_4g', displayName: 'iPod nano 4th generation' },
+  '0x1265': { generation: 'nano_5g', displayName: 'iPod nano 5th generation' },
+  '0x1266': { generation: 'nano_6g', displayName: 'iPod nano 6th generation' },
+  '0x1267': { generation: 'nano_7g', displayName: 'iPod nano 7th generation' },
+
+  // ── iPod shuffle ────────────────────────────────────────────────────────
+  '0x1300': { generation: 'shuffle_1g', displayName: 'iPod shuffle 1st generation' },
+  '0x1301': { generation: 'shuffle_2g', displayName: 'iPod shuffle 2nd generation' },
+  '0x1302': { generation: 'shuffle_3g', displayName: 'iPod shuffle 3rd generation' },
+  '0x1303': { generation: 'shuffle_4g', displayName: 'iPod shuffle 4th generation' },
+
+  // ── iPod touch ──────────────────────────────────────────────────────────
+  '0x1291': { generation: 'touch_1g', displayName: 'iPod touch 1st generation' },
+  '0x1292': { generation: 'touch_2g', displayName: 'iPod touch 2nd generation' },
+  '0x1293': { generation: 'touch_3g', displayName: 'iPod touch 3rd generation' },
+  '0x129a': { generation: 'touch_4g', displayName: 'iPod touch 4th generation' },
+  '0x12a0': { generation: 'touch_5g', displayName: 'iPod touch 5th generation' },
+  '0x12ab': { generation: 'touch_6g', displayName: 'iPod touch 6th generation' },
+  '0x12a8': { generation: 'touch_7g', displayName: 'iPod touch 7th generation' },
+};
+
+// ── Model number registry ───────────────────────────────────────────────────
+//
+// Maps model numbers (without "M" prefix) to variant information.
+// SysInfo stores "MA147"; we strip the "M" prefix to get "A147".
+//
+// Sources: libgpod itdb_device.c ipod_info_table, @podkit/ipod-db MODEL_TABLE.
+// Note: Duplicates data from @podkit/ipod-db -- that package is the canonical
+// source for model capabilities. This table focuses on identification lookups.
+
+interface ModelEntry {
+  displayName: string;
+  generation: IpodGenerationId;
+  capacityGb?: number;
+  color?: string;
+}
+
+const MODEL_NUMBERS: Record<string, ModelEntry> = {
+  // ── iPod (1st Generation) ───────────────────────────────────────────────
+  '8513': { displayName: 'iPod 5GB (1st Generation)', generation: 'classic_1g', capacityGb: 5 },
+  '8541': { displayName: 'iPod 5GB (1st Generation)', generation: 'classic_1g', capacityGb: 5 },
+  '8697': { displayName: 'iPod 5GB (1st Generation)', generation: 'classic_1g', capacityGb: 5 },
+  '8709': {
+    displayName: 'iPod 10GB (1st Generation)',
+    generation: 'classic_1g',
+    capacityGb: 10,
+  },
+
+  // ── iPod (2nd Generation) ───────────────────────────────────────────────
+  '8737': {
+    displayName: 'iPod 10GB (2nd Generation)',
+    generation: 'classic_2g',
+    capacityGb: 10,
+  },
+  '8738': {
+    displayName: 'iPod 20GB (2nd Generation)',
+    generation: 'classic_2g',
+    capacityGb: 20,
+  },
+  '8740': {
+    displayName: 'iPod 10GB (2nd Generation)',
+    generation: 'classic_2g',
+    capacityGb: 10,
+  },
+  '8741': {
+    displayName: 'iPod 20GB (2nd Generation)',
+    generation: 'classic_2g',
+    capacityGb: 20,
+  },
+
+  // ── iPod (3rd Generation) ───────────────────────────────────────────────
+  '8946': {
+    displayName: 'iPod 15GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 15,
+  },
+  '8948': {
+    displayName: 'iPod 30GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 30,
+  },
+  '8976': {
+    displayName: 'iPod 10GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 10,
+  },
+  '9244': {
+    displayName: 'iPod 20GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 20,
+  },
+  '9245': {
+    displayName: 'iPod 40GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 40,
+  },
+  '9460': {
+    displayName: 'iPod 15GB (3rd Generation)',
+    generation: 'classic_3g',
+    capacityGb: 15,
+  },
+
+  // ── iPod (4th Generation) ───────────────────────────────────────────────
+  '9268': {
+    displayName: 'iPod 40GB (4th Generation)',
+    generation: 'classic_4g',
+    capacityGb: 40,
+  },
+  '9282': {
+    displayName: 'iPod 20GB (4th Generation)',
+    generation: 'classic_4g',
+    capacityGb: 20,
+  },
+  '9787': {
+    displayName: 'iPod U2 25GB (4th Generation)',
+    generation: 'classic_4g',
+    capacityGb: 25,
+  },
+
+  // ── iPod Photo ──────────────────────────────────────────────────────────
+  '9585': { displayName: 'iPod Photo 40GB', generation: 'photo', capacityGb: 40 },
+  '9586': { displayName: 'iPod Photo 60GB', generation: 'photo', capacityGb: 60 },
+  '9829': { displayName: 'iPod Photo 30GB', generation: 'photo', capacityGb: 30 },
+  '9830': { displayName: 'iPod Photo 60GB', generation: 'photo', capacityGb: 60 },
+  A079: { displayName: 'iPod Photo 20GB', generation: 'photo', capacityGb: 20 },
+  A127: { displayName: 'iPod Photo 20GB U2', generation: 'photo', capacityGb: 20 },
+
+  // ── iPod Video (5th Generation) ─────────────────────────────────────────
+  A002: {
+    displayName: 'iPod Video 30GB White (5th Generation)',
+    generation: 'video_5g',
+    capacityGb: 30,
+    color: 'White',
+  },
+  A003: {
+    displayName: 'iPod Video 60GB White (5th Generation)',
+    generation: 'video_5g',
+    capacityGb: 60,
+    color: 'White',
+  },
+  A146: {
+    displayName: 'iPod Video 30GB Black (5th Generation)',
+    generation: 'video_5g',
+    capacityGb: 30,
+    color: 'Black',
+  },
+  A147: {
+    displayName: 'iPod Video 60GB Black (5th Generation)',
+    generation: 'video_5g',
+    capacityGb: 60,
+    color: 'Black',
+  },
+
+  // ── iPod Video (5.5th Generation) ───────────────────────────────────────
+  A444: {
+    displayName: 'iPod Video 30GB White (5.5th Generation)',
+    generation: 'video_5_5g',
+    capacityGb: 30,
+    color: 'White',
+  },
+  A446: {
+    displayName: 'iPod Video 30GB Black (5.5th Generation)',
+    generation: 'video_5_5g',
+    capacityGb: 30,
+    color: 'Black',
+  },
+  A448: {
+    displayName: 'iPod Video 80GB White (5.5th Generation)',
+    generation: 'video_5_5g',
+    capacityGb: 80,
+    color: 'White',
+  },
+  A450: {
+    displayName: 'iPod Video 80GB Black (5.5th Generation)',
+    generation: 'video_5_5g',
+    capacityGb: 80,
+    color: 'Black',
+  },
+  A664: {
+    displayName: 'iPod Video 30GB U2 (5.5th Generation)',
+    generation: 'video_5_5g',
+    capacityGb: 30,
+  },
+
+  // ── iPod Classic (6th Generation) ───────────────────────────────────────
+  B029: {
+    displayName: 'iPod Classic 80GB Silver (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 80,
+    color: 'Silver',
+  },
+  B145: {
+    displayName: 'iPod Classic 160GB Silver (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 160,
+    color: 'Silver',
+  },
+  B147: {
+    displayName: 'iPod Classic 80GB Black (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 80,
+    color: 'Black',
+  },
+  B150: {
+    displayName: 'iPod Classic 160GB Black (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 160,
+    color: 'Black',
+  },
+  B562: {
+    displayName: 'iPod Classic 120GB Silver (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 120,
+    color: 'Silver',
+  },
+  B565: {
+    displayName: 'iPod Classic 120GB Black (6th Generation)',
+    generation: 'classic_6g',
+    capacityGb: 120,
+    color: 'Black',
+  },
+
+  // ── iPod Classic (7th Generation) ───────────────────────────────────────
+  C293: {
+    displayName: 'iPod Classic 160GB Silver (7th Generation)',
+    generation: 'classic_7g',
+    capacityGb: 160,
+    color: 'Silver',
+  },
+  C297: {
+    displayName: 'iPod Classic 160GB Black (7th Generation)',
+    generation: 'classic_7g',
+    capacityGb: 160,
+    color: 'Black',
+  },
+
+  // ── iPod mini (1st Generation) ──────────────────────────────────────────
+  '9160': {
+    displayName: 'iPod mini 4GB (1st Generation)',
+    generation: 'mini_1g',
+    capacityGb: 4,
+  },
+  '9434': {
+    displayName: 'iPod mini 4GB Green (1st Generation)',
+    generation: 'mini_1g',
+    capacityGb: 4,
+    color: 'Green',
+  },
+  '9435': {
+    displayName: 'iPod mini 4GB Pink (1st Generation)',
+    generation: 'mini_1g',
+    capacityGb: 4,
+    color: 'Pink',
+  },
+  '9436': {
+    displayName: 'iPod mini 4GB Blue (1st Generation)',
+    generation: 'mini_1g',
+    capacityGb: 4,
+    color: 'Blue',
+  },
+  '9437': {
+    displayName: 'iPod mini 4GB Gold (1st Generation)',
+    generation: 'mini_1g',
+    capacityGb: 4,
+    color: 'Gold',
+  },
+
+  // ── iPod mini (2nd Generation) ──────────────────────────────────────────
+  '9800': {
+    displayName: 'iPod mini 4GB (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 4,
+  },
+  '9801': {
+    displayName: 'iPod mini 6GB (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 6,
+  },
+  '9802': {
+    displayName: 'iPod mini 4GB Blue (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 4,
+    color: 'Blue',
+  },
+  '9803': {
+    displayName: 'iPod mini 6GB Blue (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 6,
+    color: 'Blue',
+  },
+  '9804': {
+    displayName: 'iPod mini 4GB Pink (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 4,
+    color: 'Pink',
+  },
+  '9805': {
+    displayName: 'iPod mini 6GB Pink (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 6,
+    color: 'Pink',
+  },
+  '9806': {
+    displayName: 'iPod mini 4GB Green (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 4,
+    color: 'Green',
+  },
+  '9807': {
+    displayName: 'iPod mini 6GB Green (2nd Generation)',
+    generation: 'mini_2g',
+    capacityGb: 6,
+    color: 'Green',
+  },
+
+  // ── iPod nano (1st Generation) ──────────────────────────────────────────
+  A004: {
+    displayName: 'iPod nano 2GB White (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 2,
+    color: 'White',
+  },
+  A005: {
+    displayName: 'iPod nano 4GB White (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 4,
+    color: 'White',
+  },
+  A099: {
+    displayName: 'iPod nano 2GB Black (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 2,
+    color: 'Black',
+  },
+  A107: {
+    displayName: 'iPod nano 4GB Black (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 4,
+    color: 'Black',
+  },
+  A350: {
+    displayName: 'iPod nano 1GB White (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 1,
+    color: 'White',
+  },
+  A352: {
+    displayName: 'iPod nano 1GB Black (1st Generation)',
+    generation: 'nano_1g',
+    capacityGb: 1,
+    color: 'Black',
+  },
+
+  // ── iPod nano (2nd Generation) ──────────────────────────────────────────
+  A426: {
+    displayName: 'iPod nano 4GB Silver (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 4,
+    color: 'Silver',
+  },
+  A428: {
+    displayName: 'iPod nano 4GB Blue (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 4,
+    color: 'Blue',
+  },
+  A477: {
+    displayName: 'iPod nano 2GB Silver (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 2,
+    color: 'Silver',
+  },
+  A487: {
+    displayName: 'iPod nano 4GB Green (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 4,
+    color: 'Green',
+  },
+  A489: {
+    displayName: 'iPod nano 4GB Pink (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 4,
+    color: 'Pink',
+  },
+  A497: {
+    displayName: 'iPod nano 8GB Black (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 8,
+    color: 'Black',
+  },
+  A725: {
+    displayName: 'iPod nano 4GB Red (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 4,
+    color: 'Red',
+  },
+  A726: {
+    displayName: 'iPod nano 8GB Red (2nd Generation)',
+    generation: 'nano_2g',
+    capacityGb: 8,
+    color: 'Red',
+  },
+
+  // ── iPod nano (3rd Generation) ──────────────────────────────────────────
+  A978: {
+    displayName: 'iPod nano 4GB Silver (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 4,
+    color: 'Silver',
+  },
+  A980: {
+    displayName: 'iPod nano 8GB Silver (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 8,
+    color: 'Silver',
+  },
+  B249: {
+    displayName: 'iPod nano 8GB Blue (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 8,
+    color: 'Blue',
+  },
+  B253: {
+    displayName: 'iPod nano 8GB Green (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 8,
+    color: 'Green',
+  },
+  B257: {
+    displayName: 'iPod nano 8GB Red (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 8,
+    color: 'Red',
+  },
+  B261: {
+    displayName: 'iPod nano 8GB Black (3rd Generation)',
+    generation: 'nano_3g',
+    capacityGb: 8,
+    color: 'Black',
+  },
+
+  // ── iPod nano (4th Generation) ──────────────────────────────────────────
+  B480: {
+    displayName: 'iPod nano 4GB Silver (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Silver',
+  },
+  B598: {
+    displayName: 'iPod nano 8GB Silver (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Silver',
+  },
+  B651: {
+    displayName: 'iPod nano 4GB Blue (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Blue',
+  },
+  B654: {
+    displayName: 'iPod nano 4GB Pink (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Pink',
+  },
+  B657: {
+    displayName: 'iPod nano 4GB Purple (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Purple',
+  },
+  B660: {
+    displayName: 'iPod nano 4GB Orange (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Orange',
+  },
+  B663: {
+    displayName: 'iPod nano 4GB Green (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Green',
+  },
+  B666: {
+    displayName: 'iPod nano 4GB Yellow (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+    color: 'Yellow',
+  },
+  B732: {
+    displayName: 'iPod nano 8GB Blue (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Blue',
+  },
+  B735: {
+    displayName: 'iPod nano 8GB Pink (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Pink',
+  },
+  B739: {
+    displayName: 'iPod nano 8GB Purple (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Purple',
+  },
+  B742: {
+    displayName: 'iPod nano 8GB Orange (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Orange',
+  },
+  B745: {
+    displayName: 'iPod nano 8GB Green (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Green',
+  },
+  B748: {
+    displayName: 'iPod nano 8GB Yellow (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Yellow',
+  },
+  B751: {
+    displayName: 'iPod nano 8GB Red (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Red',
+  },
+  B754: {
+    displayName: 'iPod nano 8GB Black (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 8,
+    color: 'Black',
+  },
+  B903: {
+    displayName: 'iPod nano 16GB Silver (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Silver',
+  },
+  B905: {
+    displayName: 'iPod nano 16GB Blue (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Blue',
+  },
+  B907: {
+    displayName: 'iPod nano 16GB Pink (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Pink',
+  },
+  B909: {
+    displayName: 'iPod nano 16GB Purple (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Purple',
+  },
+  B911: {
+    displayName: 'iPod nano 16GB Orange (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Orange',
+  },
+  B913: {
+    displayName: 'iPod nano 16GB Green (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Green',
+  },
+  B915: {
+    displayName: 'iPod nano 16GB Yellow (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Yellow',
+  },
+  B917: {
+    displayName: 'iPod nano 16GB Red (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Red',
+  },
+  B918: {
+    displayName: 'iPod nano 16GB Black (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 16,
+    color: 'Black',
+  },
+  B867: {
+    displayName: 'iPod nano 4GB (4th Generation)',
+    generation: 'nano_4g',
+    capacityGb: 4,
+  },
+
+  // ── iPod nano (5th Generation) ──────────────────────────────────────────
+  C027: {
+    displayName: 'iPod nano 8GB Silver (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Silver',
+  },
+  C031: {
+    displayName: 'iPod nano 8GB Black (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Black',
+  },
+  C034: {
+    displayName: 'iPod nano 8GB Purple (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Purple',
+  },
+  C037: {
+    displayName: 'iPod nano 8GB Blue (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Blue',
+  },
+  C040: {
+    displayName: 'iPod nano 8GB Green (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Green',
+  },
+  C046: {
+    displayName: 'iPod nano 8GB Orange (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Orange',
+  },
+  C049: {
+    displayName: 'iPod nano 8GB Red (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Red',
+  },
+  C050: {
+    displayName: 'iPod nano 8GB Pink (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 8,
+    color: 'Pink',
+  },
+  C060: {
+    displayName: 'iPod nano 16GB Silver (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Silver',
+  },
+  C062: {
+    displayName: 'iPod nano 16GB Black (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Black',
+  },
+  C064: {
+    displayName: 'iPod nano 16GB Purple (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Purple',
+  },
+  C066: {
+    displayName: 'iPod nano 16GB Blue (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Blue',
+  },
+  C068: {
+    displayName: 'iPod nano 16GB Green (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Green',
+  },
+  C070: {
+    displayName: 'iPod nano 16GB Yellow (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Yellow',
+  },
+  C072: {
+    displayName: 'iPod nano 16GB Orange (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Orange',
+  },
+  C074: {
+    displayName: 'iPod nano 16GB Red (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Red',
+  },
+  C075: {
+    displayName: 'iPod nano 16GB Pink (5th Generation)',
+    generation: 'nano_5g',
+    capacityGb: 16,
+    color: 'Pink',
+  },
+
+  // ── iPod nano (6th Generation) ──────────────────────────────────────────
+  C525: {
+    displayName: 'iPod nano 8GB Silver (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Silver',
+  },
+  C526: {
+    displayName: 'iPod nano 16GB Silver (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Silver',
+  },
+  C688: {
+    displayName: 'iPod nano 8GB Black (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Black',
+  },
+  C689: {
+    displayName: 'iPod nano 8GB Blue (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Blue',
+  },
+  C690: {
+    displayName: 'iPod nano 8GB Green (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Green',
+  },
+  C691: {
+    displayName: 'iPod nano 8GB Orange (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Orange',
+  },
+  C692: {
+    displayName: 'iPod nano 8GB Pink (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Pink',
+  },
+  C693: {
+    displayName: 'iPod nano 8GB Red (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 8,
+    color: 'Red',
+  },
+  C694: {
+    displayName: 'iPod nano 16GB Black (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Black',
+  },
+  C695: {
+    displayName: 'iPod nano 16GB Blue (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Blue',
+  },
+  C696: {
+    displayName: 'iPod nano 16GB Green (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Green',
+  },
+  C697: {
+    displayName: 'iPod nano 16GB Orange (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Orange',
+  },
+  C698: {
+    displayName: 'iPod nano 16GB Pink (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Pink',
+  },
+  C699: {
+    displayName: 'iPod nano 16GB Red (6th Generation)',
+    generation: 'nano_6g',
+    capacityGb: 16,
+    color: 'Red',
+  },
+
+  // ── iPod nano (7th Generation) ──────────────────────────────────────────
+  D477: {
+    displayName: 'iPod nano 16GB (7th Generation)',
+    generation: 'nano_7g',
+    capacityGb: 16,
+  },
+
+  // ── iPod shuffle (1st Generation) ───────────────────────────────────────
+  '9724': {
+    displayName: 'iPod shuffle 512MB (1st Generation)',
+    generation: 'shuffle_1g',
+    capacityGb: 0.5,
+  },
+  '9725': {
+    displayName: 'iPod shuffle 1GB (1st Generation)',
+    generation: 'shuffle_1g',
+    capacityGb: 1,
+  },
+
+  // ── iPod shuffle (2nd Generation) ───────────────────────────────────────
+  A546: {
+    displayName: 'iPod shuffle 1GB Silver (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Silver',
+  },
+  A947: {
+    displayName: 'iPod shuffle 1GB Pink (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Pink',
+  },
+  A949: {
+    displayName: 'iPod shuffle 1GB Blue (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Blue',
+  },
+  A951: {
+    displayName: 'iPod shuffle 1GB Green (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Green',
+  },
+  A953: {
+    displayName: 'iPod shuffle 1GB Orange (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Orange',
+  },
+  B225: {
+    displayName: 'iPod shuffle 1GB Silver (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Silver',
+  },
+  B228: {
+    displayName: 'iPod shuffle 1GB Blue (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Blue',
+  },
+  B233: {
+    displayName: 'iPod shuffle 1GB Purple (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Purple',
+  },
+  B518: {
+    displayName: 'iPod shuffle 2GB Silver (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 2,
+    color: 'Silver',
+  },
+  C167: {
+    displayName: 'iPod shuffle 1GB Gold (2nd Generation)',
+    generation: 'shuffle_2g',
+    capacityGb: 1,
+    color: 'Gold',
+  },
+
+  // ── iPod shuffle (3rd Generation) ───────────────────────────────────────
+  C306: {
+    displayName: 'iPod shuffle 2GB Silver (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 2,
+    color: 'Silver',
+  },
+  C323: {
+    displayName: 'iPod shuffle 2GB Black (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 2,
+    color: 'Black',
+  },
+  C381: {
+    displayName: 'iPod shuffle 2GB Green (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 2,
+    color: 'Green',
+  },
+  C384: {
+    displayName: 'iPod shuffle 2GB Blue (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 2,
+    color: 'Blue',
+  },
+  C387: {
+    displayName: 'iPod shuffle 2GB Pink (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 2,
+    color: 'Pink',
+  },
+  C164: {
+    displayName: 'iPod shuffle 4GB Black (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 4,
+    color: 'Black',
+  },
+  C303: {
+    displayName: 'iPod shuffle 4GB Stainless (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 4,
+    color: 'Stainless',
+  },
+  C307: {
+    displayName: 'iPod shuffle 4GB Green (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 4,
+    color: 'Green',
+  },
+  C328: {
+    displayName: 'iPod shuffle 4GB Blue (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 4,
+    color: 'Blue',
+  },
+  C331: {
+    displayName: 'iPod shuffle 4GB Pink (3rd Generation)',
+    generation: 'shuffle_3g',
+    capacityGb: 4,
+    color: 'Pink',
+  },
+
+  // ── iPod shuffle (4th Generation) ───────────────────────────────────────
+  C584: {
+    displayName: 'iPod shuffle 2GB Silver (4th Generation)',
+    generation: 'shuffle_4g',
+    capacityGb: 2,
+    color: 'Silver',
+  },
+  C585: {
+    displayName: 'iPod shuffle 2GB Pink (4th Generation)',
+    generation: 'shuffle_4g',
+    capacityGb: 2,
+    color: 'Pink',
+  },
+  C749: {
+    displayName: 'iPod shuffle 2GB Orange (4th Generation)',
+    generation: 'shuffle_4g',
+    capacityGb: 2,
+    color: 'Orange',
+  },
+  C750: {
+    displayName: 'iPod shuffle 2GB Green (4th Generation)',
+    generation: 'shuffle_4g',
+    capacityGb: 2,
+    color: 'Green',
+  },
+  C751: {
+    displayName: 'iPod shuffle 2GB Blue (4th Generation)',
+    generation: 'shuffle_4g',
+    capacityGb: 2,
+    color: 'Blue',
+  },
+
+  // ── iPod touch (1st Generation) ─────────────────────────────────────────
+  A623: {
+    displayName: 'iPod touch 8GB (1st Generation)',
+    generation: 'touch_1g',
+    capacityGb: 8,
+  },
+  A627: {
+    displayName: 'iPod touch 16GB (1st Generation)',
+    generation: 'touch_1g',
+    capacityGb: 16,
+  },
+  B376: {
+    displayName: 'iPod touch 32GB (1st Generation)',
+    generation: 'touch_1g',
+    capacityGb: 32,
+  },
+
+  // ── iPod touch (2nd Generation) ─────────────────────────────────────────
+  B528: {
+    displayName: 'iPod touch 8GB (2nd Generation)',
+    generation: 'touch_2g',
+    capacityGb: 8,
+  },
+  B531: {
+    displayName: 'iPod touch 16GB (2nd Generation)',
+    generation: 'touch_2g',
+    capacityGb: 16,
+  },
+
+  // ── iPod touch (3rd Generation) ─────────────────────────────────────────
+  C008: {
+    displayName: 'iPod touch 32GB (3rd Generation)',
+    generation: 'touch_3g',
+    capacityGb: 32,
+  },
+  C011: {
+    displayName: 'iPod touch 64GB (3rd Generation)',
+    generation: 'touch_3g',
+    capacityGb: 64,
+  },
+  C086: {
+    displayName: 'iPod touch 8GB (3rd Generation)',
+    generation: 'touch_2g', // Hardware is 2nd gen; marketed as 3rd gen
+    capacityGb: 8,
+  },
+
+  // ── iPod touch (4th Generation) ─────────────────────────────────────────
+  C540: {
+    displayName: 'iPod touch 8GB (4th Generation)',
+    generation: 'touch_4g',
+    capacityGb: 8,
+  },
+  C544: {
+    displayName: 'iPod touch 32GB (4th Generation)',
+    generation: 'touch_4g',
+    capacityGb: 32,
+  },
+  C547: {
+    displayName: 'iPod touch 64GB (4th Generation)',
+    generation: 'touch_4g',
+    capacityGb: 64,
+  },
+};
+
+// ── Serial suffix to model number mapping ───────────────────────────────────
+//
+// Maps the last 3 characters of an iPod serial number to model numbers.
+// The model number (prepended with "M") is the SysInfo ModelNumStr.
+//
+// Source: libgpod itdb_device.c serial_to_model_mapping (lines 633-868).
+// Example: serial "5U8280FNYXX" -> suffix "YXX" -> model "B261" -> "MB261"
+//        -> "iPod nano 8GB Black (3rd Generation)"
+//
+// Note: Some suffixes map to the same model. Where libgpod had duplicate
+// suffix entries with different models, the last entry wins (matching C behavior).
+
+const SERIAL_SUFFIX_TO_MODEL: Record<string, string> = {
+  // iPod (1st Generation)
+  LG6: '8541',
+  NAM: '8541',
+  MJ2: '8541',
+  ML1: '8709',
+  MME: '8709',
+
+  // iPod (2nd Generation)
+  MMB: '8737',
+  MMC: '8738',
+  NGE: '8740',
+  NGH: '8740',
+  MMF: '8741',
+
+  // iPod (3rd Generation)
+  NLW: '8946',
+  NRH: '8976',
+  QQF: '9460',
+  PQ5: '9244',
+  PNT: '9244',
+  NLY: '8948',
+  NM7: '8948',
+  PNU: '9245',
+  PS9: '9282',
+  Q8U: '9282',
+
+  // iPod (4th Generation)
+  V9V: '9787',
+  S2X: '9787',
+  PQ7: '9268',
+
+  // iPod Photo
+  TDU: 'A079',
+  TDS: 'A079',
+  TM2: 'A127',
+  SAZ: '9830',
+  SB1: '9830',
+  SAY: '9829',
+  R5Q: '9585',
+  R5R: '9586',
+  R5T: '9586',
+
+  // iPod mini (1st Generation)
+  PFW: '9160',
+  PRC: '9160',
+  QKL: '9436',
+  QKQ: '9436',
+  QKK: '9435',
+  QKP: '9435',
+  QKJ: '9434',
+  QKN: '9434',
+  QKM: '9437',
+  QKR: '9437',
+
+  // iPod mini (2nd Generation)
+  S41: '9800',
+  S4C: '9800',
+  S43: '9802',
+  S45: '9804',
+  S47: '9806',
+  S4J: '9806',
+  S42: '9801',
+  S44: '9803',
+  S48: '9807',
+
+  // iPod shuffle (1st Generation)
+  RS9: '9724',
+  QGV: '9724',
+  TSX: '9724',
+  PFV: '9724',
+  R80: '9724',
+  RSA: '9725',
+  TSY: '9725',
+  C60: '9725',
+
+  // iPod shuffle (2nd Generation)
+  VTE: 'A546',
+  VTF: 'A546',
+  XQ5: 'A947',
+  XQS: 'A947',
+  XQV: 'A949',
+  XQX: 'A949',
+  XQY: 'A951',
+  XR1: 'A953',
+  '1ZH': 'B518',
+  '8CQ': 'C167',
+  // YX7 appears for both nano_1g (A949) and shuffle_2g (B228) in libgpod.
+  // YX9 appears for shuffle_2g (B225). In C, last-wins = shuffle_2g entries.
+  YX7: 'B228',
+  YX9: 'B225',
+  YXA: 'B233',
+  YX6: 'B225',
+  YX8: 'A951',
+
+  // iPod nano (1st Generation)
+  UNA: 'A350',
+  UNB: 'A350',
+  UPR: 'A352',
+  UPS: 'A352',
+  SZB: 'A004',
+  SZV: 'A004',
+  SZW: 'A004',
+  SZC: 'A005',
+  SZT: 'A005',
+  TJT: 'A099',
+  TJU: 'A099',
+  TK2: 'A107',
+  TK3: 'A107',
+
+  // iPod nano (2nd Generation)
+  VQ5: 'A477',
+  VQ6: 'A477',
+  V8T: 'A426',
+  V8U: 'A426',
+  V8W: 'A428',
+  V8X: 'A428',
+  VQH: 'A487',
+  VQJ: 'A487',
+  VQK: 'A489',
+  VKL: 'A489',
+  WL2: 'A725',
+  WL3: 'A725',
+  X9A: 'A726',
+  X9B: 'A726',
+  VQT: 'A497',
+  VQU: 'A497',
+
+  // iPod Video (5th Generation)
+  SZ9: 'A002',
+  WEC: 'A002',
+  WED: 'A002',
+  WEG: 'A002',
+  WEH: 'A002',
+  WEL: 'A002',
+  TXK: 'A146',
+  TXM: 'A146',
+  // WEE appears for both video_5g (A146) and video_5_5g (A446) in libgpod.
+  // In C, last-wins semantics apply, so A446 is correct.
+  WEE: 'A446',
+  WEF: 'A146',
+  WEJ: 'A146',
+  WEK: 'A146',
+  SZA: 'A003',
+  SZU: 'A003',
+  TXL: 'A147',
+  TXN: 'A147',
+
+  // iPod Video (5.5th Generation)
+  V9K: 'A444',
+  V9L: 'A444',
+  WU9: 'A444',
+  VQM: 'A446',
+  V9M: 'A446',
+  V9N: 'A446',
+  V9P: 'A448',
+  V9Q: 'A448',
+  V9R: 'A450',
+  V9S: 'A450',
+  V95: 'A450',
+  V96: 'A450',
+  WUC: 'A450',
+  W9G: 'A664',
+
+  // iPod Classic (6th Generation)
+  Y5N: 'B029',
+  YMV: 'B147',
+  YMU: 'B145',
+  YMX: 'B150',
+
+  // iPod Classic (6th Generation, revised -- 120GB)
+  '2C5': 'B562',
+  '2C7': 'B565',
+
+  // iPod Classic (7th Generation)
+  '9ZS': 'C293',
+  '9ZU': 'C297',
+
+  // iPod nano (3rd Generation)
+  Y0P: 'A978',
+  Y0R: 'A980',
+  YXR: 'B249',
+  YXV: 'B257',
+  YXT: 'B253',
+  YXX: 'B261',
+
+  // iPod nano (4th Generation)
+  '37P': 'B663',
+  '37Q': 'B666',
+  '37H': 'B654',
+  '1P1': 'B480',
+  '37K': 'B657',
+  '37L': 'B660',
+  '2ME': 'B598',
+  '3QS': 'B732',
+  '3QT': 'B735',
+  '3QU': 'B739',
+  '3QW': 'B742',
+  '3QX': 'B745',
+  '3QY': 'B748',
+  '3R0': 'B754',
+  '3QZ': 'B751',
+  '5B7': 'B903',
+  '5B8': 'B905',
+  '5B9': 'B907',
+  '5BA': 'B909',
+  '5BB': 'B911',
+  '5BC': 'B913',
+  '5BD': 'B915',
+  '5BE': 'B917',
+  '5BF': 'B918',
+
+  // iPod nano (5th Generation)
+  '71V': 'C027',
+  '71Y': 'C031',
+  '721': 'C034',
+  '726': 'C037',
+  '72A': 'C040',
+  '72F': 'C046',
+  '72K': 'C049',
+  '72L': 'C050',
+  '72Q': 'C060',
+  '72R': 'C062',
+  '72S': 'C064',
+  '72X': 'C066',
+  '734': 'C068',
+  '738': 'C070',
+  '739': 'C072',
+  '73A': 'C074',
+  '73B': 'C075',
+
+  // iPod nano (6th Generation)
+  CMN: 'C525',
+  DVX: 'C688',
+  DVY: 'C689',
+  DW0: 'C690',
+  DW1: 'C691',
+  DW2: 'C692',
+  DW3: 'C693',
+  CMP: 'C526',
+  DW4: 'C694',
+  DW5: 'C695',
+  DW6: 'C696',
+  DW7: 'C697',
+  DW8: 'C698',
+  DW9: 'C699',
+
+  // iPod shuffle (3rd Generation)
+  A1S: 'C306',
+  A78: 'C323',
+  ALB: 'C381',
+  ALD: 'C384',
+  ALG: 'C387',
+  '4NZ': 'B867',
+  '891': 'C164',
+  A1L: 'C303',
+  A1U: 'C307',
+  A7B: 'C328',
+  A7D: 'C331',
+
+  // iPod shuffle (4th Generation)
+  CMJ: 'C584',
+  CMK: 'C585',
+  FDM: 'C749',
+  FDN: 'C750',
+  FDP: 'C751',
+
+  // iPod touch (1st Generation)
+  W4N: 'A623',
+  W4T: 'A627',
+  '0JW': 'B376',
+
+  // iPod touch (2nd Generation)
+  '201': 'B528',
+  '203': 'B531',
+
+  // iPod touch (3rd Generation)
+  '75J': 'C086',
+  '6K2': 'C008',
+  '6K4': 'C011',
+};
+
+// Duplicate-suffix handling: libgpod's C array has duplicate keys where "last wins".
+// YX7 (shuffle_2g B228 vs nano_1g A949), YX9 (shuffle_2g B225), and WEE (video_5_5g A446
+// vs video_5g A146) are resolved inline above using libgpod's last-wins ordering.
+
+// ── Backward-compatible SysInfo model names ─────────────────────────────────
+//
+// This provides the same lookup as the old SYSINFO_MODEL_NAMES table, now backed
+// by the unified MODEL_NUMBERS registry. The old table used "MA147" format keys;
+// we normalise by stripping the "M" prefix in the lookup function.
+//
+// Entries that existed in the old table but NOT in MODEL_NUMBERS are preserved
+// here for backward compatibility. The old table had some entries with "LL" suffix
+// (e.g., "MA099LL") and "MC477" which we include.
+
+const LEGACY_MODEL_OVERRIDES: Record<string, string> = {
+  // MA099LL was in the old table -- a locale-specific SKU
+  A099LL: 'iPod nano 1GB (1st Generation)',
+  // MC477 was in the old table but not in ipod-db -- a late Classic 7G SKU
+  C477: 'iPod Classic 160GB (7th Generation)',
+  // MB263 was in the old table -- a nano 4G SKU not in libgpod or ipod-db
+  B263: 'iPod nano 4GB (4th Generation)',
+};
+
+// ── Lookup indexes (populated once) ─────────────────────────────────────────
+
+const USB_INDEX = new Map<string, UsbProductIdEntry>();
+for (const [id, entry] of Object.entries(USB_PRODUCT_IDS)) {
+  USB_INDEX.set(id.toLowerCase(), entry);
+}
+
+const MODEL_INDEX = new Map<string, ModelEntry>();
+for (const [num, entry] of Object.entries(MODEL_NUMBERS)) {
+  MODEL_INDEX.set(num.toUpperCase(), entry);
+}
+// Add legacy overrides
+for (const [num, displayName] of Object.entries(LEGACY_MODEL_OVERRIDES)) {
+  if (!MODEL_INDEX.has(num.toUpperCase())) {
+    // Infer generation from nearby entries or default
+    const gen: IpodGenerationId = num.startsWith('A099')
+      ? 'nano_1g'
+      : num === 'C477'
+        ? 'classic_7g'
+        : num === 'B263'
+          ? 'nano_4g'
+          : 'classic_1g';
+    MODEL_INDEX.set(num.toUpperCase(), { displayName, generation: gen });
+  }
+}
+
+const SERIAL_INDEX = new Map<string, string>();
+for (const [suffix, model] of Object.entries(SERIAL_SUFFIX_TO_MODEL)) {
+  SERIAL_INDEX.set(suffix.toUpperCase(), model.toUpperCase());
+}
+
+// ── Public API: backward-compatible functions ───────────────────────────────
 
 /**
  * Look up a human-readable model name from an Apple USB product ID.
  *
  * @param productId - Hex product ID string, with or without leading zeros
- *                    (e.g., "0x1209", "0x1209")
+ *                    (e.g., "0x1209", "1209")
  * @returns Model name if the ID is in the lookup table, undefined otherwise
  */
 export function lookupIpodModel(productId: string): string | undefined {
-  // Normalise to lowercase with 0x prefix for consistent lookup
   const normalised = productId.toLowerCase().startsWith('0x')
     ? productId.toLowerCase()
     : `0x${productId.toLowerCase()}`;
 
-  return IPOD_MODELS[normalised];
+  return USB_INDEX.get(normalised)?.displayName;
 }
-
-/**
- * iPod SysInfo model number to human-readable name mapping.
- *
- * Maps `ModelNumStr` values found in `iPod_Control/Device/SysInfo` to
- * human-readable model descriptions. These are Apple internal model numbers
- * (e.g. "MA147"), distinct from USB product IDs used by `lookupIpodModel`.
- *
- * Sources: libgpod source, community databases, and direct device testing.
- */
-const SYSINFO_MODEL_NAMES: Record<string, string> = {
-  // -------------------------------------------------------------------------
-  // iPod (1st–4th gen)
-  // -------------------------------------------------------------------------
-  M8513: 'iPod 5GB (1st generation)',
-  M8737: 'iPod 10GB (2nd generation)',
-  M8976: 'iPod 10GB (3rd generation)',
-  M9282: 'iPod 20GB (4th generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod Photo
-  // -------------------------------------------------------------------------
-  MA079: 'iPod Photo 20GB',
-  MA127: 'iPod Photo 60GB',
-
-  // -------------------------------------------------------------------------
-  // iPod Video (5th gen)
-  // -------------------------------------------------------------------------
-  MA002: 'iPod Video 30GB (5th generation)',
-  MA003: 'iPod Video 60GB (5th generation)',
-  MA146: 'iPod Video 30GB (5th generation)',
-  MA147: 'iPod Video 60GB (5th generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod Video (5.5th gen)
-  // -------------------------------------------------------------------------
-  MA444: 'iPod Video 30GB (5.5th generation)',
-  MA446: 'iPod Video 80GB (5.5th generation)',
-  MA448: 'iPod Video 30GB (5.5th generation)',
-  MA450: 'iPod Video 80GB (5.5th generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod Classic (6th gen)
-  // -------------------------------------------------------------------------
-  MB029: 'iPod Classic 80GB (6th generation)',
-  MB147: 'iPod Classic 160GB (6th generation)',
-  MB565: 'iPod Classic 120GB (6th generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod Classic (7th gen)
-  // -------------------------------------------------------------------------
-  MC293: 'iPod Classic 160GB (7th generation)',
-  MC297: 'iPod Classic 160GB (7th generation)',
-  MC477: 'iPod Classic 160GB (7th generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod mini
-  // -------------------------------------------------------------------------
-  M9160: 'iPod mini 4GB (1st generation)',
-  M9436: 'iPod mini 6GB (1st generation)',
-  M9800: 'iPod mini 4GB (2nd generation)',
-  M9802: 'iPod mini 6GB (2nd generation)',
-
-  // -------------------------------------------------------------------------
-  // iPod nano (1st–7th gen)
-  // -------------------------------------------------------------------------
-  MA004: 'iPod nano 1GB (1st generation)',
-  MA005: 'iPod nano 2GB (1st generation)',
-  MA099: 'iPod nano 1GB (1st generation)',
-  MA107: 'iPod nano 4GB (1st generation)',
-  MA099LL: 'iPod nano 1GB (1st generation)',
-  MA477: 'iPod nano 2GB (2nd generation)',
-  MA428: 'iPod nano 4GB (2nd generation)',
-  MA489: 'iPod nano 8GB (2nd generation)',
-  MB261: 'iPod nano 4GB (3rd generation)',
-  MB257: 'iPod nano 8GB (3rd generation)',
-  MB263: 'iPod nano 4GB (4th generation)',
-  MB598: 'iPod nano 8GB (4th generation)',
-  MC027: 'iPod nano 8GB (5th generation)',
-  MC031: 'iPod nano 16GB (5th generation)',
-  MC525: 'iPod nano 8GB (6th generation)',
-  MD477: 'iPod nano 16GB (7th generation)',
-};
 
 /**
  * Look up a human-readable model name from an iPod SysInfo model number string.
@@ -161,5 +1578,92 @@ const SYSINFO_MODEL_NAMES: Record<string, string> = {
  * @returns Model name if the model number is known, undefined otherwise
  */
 export function lookupIpodModelByNumber(modelNumStr: string): string | undefined {
-  return SYSINFO_MODEL_NAMES[modelNumStr.toUpperCase()];
+  const upper = modelNumStr.toUpperCase();
+
+  // Strip leading "M" if present (SysInfo format -> internal format)
+  const stripped = upper.startsWith('M') ? upper.slice(1) : upper;
+
+  // Try the stripped form first, then the full form (for entries like "A099LL")
+  const entry = MODEL_INDEX.get(stripped) ?? MODEL_INDEX.get(upper);
+  return entry?.displayName;
+}
+
+// ── Public API: new functions ───────────────────────────────────────────────
+
+/**
+ * Look up a specific iPod model variant from a serial number suffix.
+ *
+ * The last 3 characters of an iPod serial number identify the exact model
+ * variant (color, capacity, generation). This maps that suffix through the
+ * model number table to return full variant information.
+ *
+ * @param serialSuffix - Last 3 characters of the iPod serial number
+ * @returns Model variant info, or undefined if the suffix is unknown
+ *
+ * @example
+ * ```ts
+ * // Serial "5U8280FNYXX" -> suffix "YXX"
+ * const variant = lookupIpodModelBySerial('YXX');
+ * // { modelNumber: 'B261', displayName: 'iPod nano 8GB Black (3rd Generation)',
+ * //   generation: 'nano_3g', capacityGb: 8, color: 'Black' }
+ * ```
+ */
+export function lookupIpodModelBySerial(serialSuffix: string): IpodModelVariant | undefined {
+  if (!serialSuffix || serialSuffix.length !== 3) return undefined;
+
+  const modelNumber = SERIAL_INDEX.get(serialSuffix.toUpperCase());
+  if (!modelNumber) return undefined;
+
+  const entry = MODEL_INDEX.get(modelNumber);
+  if (!entry) {
+    // Model number exists in serial table but not in model table.
+    // Return minimal info using the model number.
+    return {
+      modelNumber,
+      displayName: `Unknown iPod (model M${modelNumber})`,
+      generation: 'classic_1g', // fallback
+    };
+  }
+
+  return {
+    modelNumber,
+    displayName: entry.displayName,
+    generation: entry.generation,
+    capacityGb: entry.capacityGb,
+    color: entry.color,
+  };
+}
+
+/**
+ * Get generation metadata for a generation identifier.
+ *
+ * @param generationId - Generation identifier
+ * @returns Generation metadata (always returns a valid result for valid IDs)
+ */
+export function getGenerationInfo(generationId: IpodGenerationId): IpodGeneration {
+  return GENERATIONS[generationId];
+}
+
+/**
+ * Get the checksum type required for a given iPod generation.
+ *
+ * @param generationId - Generation identifier
+ * @returns Checksum type: 'none', 'hash58', 'hash72', or 'hashAB'
+ */
+export function getChecksumType(generationId: IpodGenerationId): IpodChecksumType {
+  return GENERATIONS[generationId].checksumType;
+}
+
+/**
+ * Look up the generation identifier for a USB product ID.
+ *
+ * @param productId - Hex product ID string (e.g., "0x1209", "1262")
+ * @returns Generation identifier, or undefined if the product ID is unknown
+ */
+export function lookupGenerationByProductId(productId: string): IpodGenerationId | undefined {
+  const normalised = productId.toLowerCase().startsWith('0x')
+    ? productId.toLowerCase()
+    : `0x${productId.toLowerCase()}`;
+
+  return USB_INDEX.get(normalised)?.generation;
 }

--- a/packages/podkit-core/src/device/ipod-models.ts
+++ b/packages/podkit-core/src/device/ipod-models.ts
@@ -1594,6 +1594,20 @@ export function lookupIpodModelByNumber(modelNumStr: string): string | undefined
   return entry?.displayName;
 }
 
+/**
+ * Get the checksum type required for a device identified by its ModelNumStr.
+ *
+ * @param modelNumStr - Model number string from SysInfo (e.g., "MA147", "MB147")
+ * @returns Checksum type, or undefined if the model number is not recognized
+ */
+export function getChecksumTypeByModelNumber(modelNumStr: string): IpodChecksumType | undefined {
+  const upper = modelNumStr.toUpperCase();
+  const stripped = /^[MPF]/.test(upper) ? upper.slice(1) : upper;
+  const entry = MODEL_INDEX.get(stripped) ?? MODEL_INDEX.get(upper);
+  if (!entry) return undefined;
+  return GENERATIONS[entry.generation].checksumType;
+}
+
 // ── Public API: new functions ───────────────────────────────────────────────
 
 /**

--- a/packages/podkit-core/src/device/ipod-models.ts
+++ b/packages/podkit-core/src/device/ipod-models.ts
@@ -1574,14 +1574,20 @@ export function lookupIpodModel(productId: string): string | undefined {
  * Look up a human-readable model name from an iPod SysInfo model number string.
  *
  * @param modelNumStr - The `ModelNumStr` value from `iPod_Control/Device/SysInfo`
- *                      (e.g., "MA147", "MC297")
+ *                      (e.g., "MA147", "P9804", "F9436")
  * @returns Model name if the model number is known, undefined otherwise
+ *
+ * Apple uses single-letter prefixes that all map to the same underlying
+ * hardware: `M` (retail), `P` (service stock / replacement unit), `F`
+ * (factory refurbished). The registry is keyed on the bare suffix, so we
+ * strip any of those before looking up.
  */
 export function lookupIpodModelByNumber(modelNumStr: string): string | undefined {
   const upper = modelNumStr.toUpperCase();
 
-  // Strip leading "M" if present (SysInfo format -> internal format)
-  const stripped = upper.startsWith('M') ? upper.slice(1) : upper;
+  // Strip a leading M / P / F prefix (Apple's retail / service / refurb
+  // prefixes, all referring to the same model).
+  const stripped = /^[MPF]/.test(upper) ? upper.slice(1) : upper;
 
   // Try the stripped form first, then the full form (for entries like "A099LL")
   const entry = MODEL_INDEX.get(stripped) ?? MODEL_INDEX.get(upper);

--- a/packages/podkit-core/src/device/platforms/linux.ts
+++ b/packages/podkit-core/src/device/platforms/linux.ts
@@ -225,11 +225,32 @@ function findUsbIdentity(blockDeviceName: string): UsbDeviceInfo | undefined {
         const vendorId = `0x${readFileSync(vendorPath, 'utf-8').trim()}`;
         const productId = `0x${readFileSync(productPath, 'utf-8').trim()}`;
 
-        return {
+        const info: UsbDeviceInfo = {
           productId,
           vendorId,
           modelName: lookupIpodModel(productId),
         };
+
+        // Read optional USB identity fields from the same sysfs node
+        const serialPath = join(sysPath, 'serial');
+        if (existsSync(serialPath)) {
+          const serial = readFileSync(serialPath, 'utf-8').trim();
+          if (serial.length > 0) info.serialNumber = serial;
+        }
+
+        const busnumPath = join(sysPath, 'busnum');
+        if (existsSync(busnumPath)) {
+          const busnum = parseInt(readFileSync(busnumPath, 'utf-8').trim(), 10);
+          if (Number.isFinite(busnum)) info.busNumber = busnum;
+        }
+
+        const devnumPath = join(sysPath, 'devnum');
+        if (existsSync(devnumPath)) {
+          const devnum = parseInt(readFileSync(devnumPath, 'utf-8').trim(), 10);
+          if (Number.isFinite(devnum)) info.deviceAddress = devnum;
+        }
+
+        return info;
       }
 
       // Move up one directory

--- a/packages/podkit-core/src/device/platforms/macos.ts
+++ b/packages/podkit-core/src/device/platforms/macos.ts
@@ -19,6 +19,7 @@ import type {
 import type { DeviceAssessment, UsbDeviceInfo } from '../assessment.js';
 import { detectIFlash } from '../assessment.js';
 import { lookupIpodModel } from '../ipod-models.js';
+import { parseLocationId } from '../usb-discovery.js';
 
 /**
  * Execute a command and return stdout
@@ -550,34 +551,46 @@ Replace diskXsY with your actual device identifier`;
    * disks (e.g., internal storage + SD card).
    */
   private findAllBsdNamesForDevice(node: unknown, targetDisk: string): string[] {
-    if (!node || typeof node !== 'object') return [];
+    const deviceNode = this.findUsbDeviceNode(node, targetDisk);
+    return deviceNode ? this.collectAllBsdNames(deviceNode) : [];
+  }
+
+  /**
+   * Walk a system_profiler JSON tree, finding the first node with a `product_id`
+   * field whose subtree contains the target `bsd_name`.
+   */
+  private findUsbDeviceNode(
+    node: unknown,
+    targetBsdName: string
+  ): Record<string, unknown> | undefined {
+    if (!node || typeof node !== 'object') return undefined;
 
     if (Array.isArray(node)) {
       for (const item of node) {
-        const result = this.findAllBsdNamesForDevice(item, targetDisk);
-        if (result.length > 0) return result;
+        const result = this.findUsbDeviceNode(item, targetBsdName);
+        if (result) return result;
       }
-      return [];
+      return undefined;
     }
 
     const record = node as Record<string, unknown>;
 
     // A USB device node has a product_id. If it contains our target BSD name,
-    // collect ALL BSD names from its entire subtree.
+    // this is the device we want.
     if (
       typeof record['product_id'] === 'string' &&
-      this.subtreeContainsBsdName(record, targetDisk)
+      this.subtreeContainsBsdName(record, targetBsdName)
     ) {
-      return this.collectAllBsdNames(record);
+      return record;
     }
 
     // Recurse into child values
     for (const value of Object.values(record)) {
-      const result = this.findAllBsdNamesForDevice(value, targetDisk);
-      if (result.length > 0) return result;
+      const result = this.findUsbDeviceNode(value, targetBsdName);
+      if (result) return result;
     }
 
-    return [];
+    return undefined;
   }
 
   /**
@@ -653,53 +666,48 @@ Replace diskXsY with your actual device identifier`;
   }
 
   /**
-   * Recursively search a system_profiler data structure for a USB device entry
-   * that owns the given whole-disk BSD name.
-   *
-   * The product_id lives on the USB device node, while bsd_name is nested
-   * inside its Media sub-array. We search for a node that has a product_id
-   * and contains the target bsd_name anywhere in its subtree.
+   * Search a system_profiler data structure for a USB device entry
+   * that owns the given whole-disk BSD name, and extract its USB info.
    */
   private findUsbDeviceByBsdName(node: unknown, wholeDisk: string): UsbDeviceInfo | undefined {
-    if (!node || typeof node !== 'object') return undefined;
+    const deviceNode = this.findUsbDeviceNode(node, wholeDisk);
+    if (!deviceNode) return undefined;
+    return this.extractUsbInfo(deviceNode);
+  }
 
-    if (Array.isArray(node)) {
-      for (const item of node) {
-        const result = this.findUsbDeviceByBsdName(item, wholeDisk);
-        if (result) return result;
-      }
-      return undefined;
+  /**
+   * Extract UsbDeviceInfo from a system_profiler USB device node.
+   *
+   * Reads product_id, vendor_id, serial_num, and location_id from
+   * the node and normalises them into the UsbDeviceInfo shape.
+   */
+  private extractUsbInfo(record: Record<string, unknown>): UsbDeviceInfo {
+    const productId = record['product_id'] as string;
+    const rawVendorId = typeof record['vendor_id'] === 'string' ? record['vendor_id'] : '';
+
+    // vendor_id may be the string "apple_vendor_id" or "0x05ac (Apple Inc.)"
+    const vendorId =
+      rawVendorId === 'apple_vendor_id' ? '0x05ac' : (rawVendorId.split(' ')[0] ?? '');
+
+    const info: UsbDeviceInfo = {
+      productId,
+      vendorId,
+      modelName: lookupIpodModel(productId),
+    };
+
+    // Extract serial number (FirewireGuid for iPods)
+    if (typeof record['serial_num'] === 'string' && record['serial_num'].length > 0) {
+      info.serialNumber = record['serial_num'];
     }
 
-    const record = node as Record<string, unknown>;
+    // Extract bus number and device address from location_id
+    const locationId =
+      typeof record['location_id'] === 'string' ? record['location_id'] : undefined;
+    const { busNumber, deviceAddress } = parseLocationId(locationId);
+    if (busNumber !== undefined) info.busNumber = busNumber;
+    if (deviceAddress !== undefined) info.deviceAddress = deviceAddress;
 
-    // If this node has a product_id and the target bsd_name appears anywhere
-    // in its subtree, this is the USB device entry we want.
-    if (
-      typeof record['product_id'] === 'string' &&
-      this.subtreeContainsBsdName(record, wholeDisk)
-    ) {
-      const productId = record['product_id'];
-      const rawVendorId = typeof record['vendor_id'] === 'string' ? record['vendor_id'] : '';
-
-      // vendor_id may be the string "apple_vendor_id" or "0x05ac (Apple Inc.)"
-      const vendorId =
-        rawVendorId === 'apple_vendor_id' ? '0x05ac' : (rawVendorId.split(' ')[0] ?? '');
-
-      return {
-        productId,
-        vendorId,
-        modelName: lookupIpodModel(productId),
-      };
-    }
-
-    // Recurse into all child values to find a matching USB device deeper in the tree
-    for (const value of Object.values(record)) {
-      const result = this.findUsbDeviceByBsdName(value, wholeDisk);
-      if (result) return result;
-    }
-
-    return undefined;
+    return info;
   }
 
   /**

--- a/packages/podkit-core/src/device/readiness.test.ts
+++ b/packages/podkit-core/src/device/readiness.test.ts
@@ -40,6 +40,33 @@ function writeSysInfo(mountPoint: string, content: string): void {
   fs.writeFileSync(path.join(deviceDir, 'SysInfo'), content);
 }
 
+function writeSysInfoExtended(mountPoint: string, xml: string): void {
+  const deviceDir = path.join(mountPoint, 'iPod_Control', 'Device');
+  fs.mkdirSync(deviceDir, { recursive: true });
+  fs.writeFileSync(path.join(deviceDir, 'SysInfoExtended'), xml);
+}
+
+/** Minimal valid SysInfoExtended plist XML */
+function makeSysInfoExtendedXml(
+  opts: {
+    firewireGuid?: string;
+    serialNumber?: string;
+  } = {}
+): string {
+  const guid = opts.firewireGuid ?? '000A27001301297E';
+  const serial = opts.serialNumber ?? '5U8280FNYXX';
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>FireWireGUID</key>
+  <string>${guid}</string>
+  <key>SerialNumber</key>
+  <string>${serial}</string>
+</dict>
+</plist>`;
+}
+
 // ── checkIpodStructure ───────────────────────────────────────────────────────
 
 describe('checkIpodStructure', () => {
@@ -88,14 +115,48 @@ describe('checkSysInfo', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('passes with valid SysInfo containing a known ModelNumStr', async () => {
-    writeSysInfo(tmpDir, 'ModelNumStr: MA147\nFirewireGuid: 0001234');
+  it('passes when SysInfoExtended is present with valid content', async () => {
+    createIpodStructure(tmpDir);
+    writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
     const result = await checkSysInfo(tmpDir);
     expect(result.status).toBe('pass');
+    expect(result.summary).toContain('SysInfoExtended');
+    expect(result.details?.sysInfoExtendedExists).toBe(true);
+    expect(result.details?.firewireGuid).toBeTruthy();
+    expect(result.details?.serialNumber).toBeTruthy();
+  });
+
+  it('passes when SysInfoExtended is present even without SysInfo', async () => {
+    createIpodStructure(tmpDir);
+    // No SysInfo, only SysInfoExtended
+    writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
+    const result = await checkSysInfo(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.summary).toContain('SysInfoExtended');
+  });
+
+  it('warns when SysInfo has known model but SysInfoExtended is missing (no-checksum device)', async () => {
+    // MA147 = iPod Video 5th gen = checksumType 'none'
+    writeSysInfo(tmpDir, 'ModelNumStr: MA147\nFirewireGuid: 0001234');
+    const result = await checkSysInfo(tmpDir);
+    expect(result.status).toBe('warn');
     expect(result.summary).toContain('MA147');
     expect(result.summary).toContain('iPod Video');
     expect(result.details?.modelNumber).toBe('MA147');
     expect(result.details?.modelName).toBeTruthy();
+    expect(result.details?.sysInfoExtendedExists).toBe(false);
+    expect(result.details?.suggestion).toContain('SysInfoExtended missing');
+  });
+
+  it('fails when SysInfo has known model but SysInfoExtended is missing (hash58 device)', async () => {
+    // MC297 = iPod Classic 7th gen = checksumType 'hash58'
+    writeSysInfo(tmpDir, 'ModelNumStr: MC297\nFirewireGuid: 0001234');
+    // Pass USB info for a Classic 7G (0x120a)
+    const result = await checkSysInfo(tmpDir, { productId: '0x120a', vendorId: '0x05ac' });
+    expect(result.status).toBe('fail');
+    expect(result.summary).toContain('SysInfoExtended required');
+    expect(result.details?.checksumType).toBe('hash58');
+    expect(result.details?.suggestion).toContain('doctor --repair sysinfo-extended');
   });
 
   it('warns when SysInfo has ModelNumStr that is not in the known model list', async () => {
@@ -107,13 +168,14 @@ describe('checkSysInfo', () => {
     expect(result.details?.suggestion).toBeTruthy();
   });
 
-  it('fails when SysInfo file is missing', async () => {
+  it('fails when both SysInfo and SysInfoExtended are missing', async () => {
     createIpodStructure(tmpDir);
     const result = await checkSysInfo(tmpDir);
     expect(result.status).toBe('fail');
     expect(result.summary).toContain('not found');
     expect(result.details?.exists).toBe(false);
-    expect(result.details?.suggestion).toBeTruthy();
+    expect(result.details?.sysInfoExtendedExists).toBe(false);
+    expect(result.details?.suggestion).toContain('doctor --repair sysinfo-extended');
   });
 
   it('fails when Device directory does not exist', async () => {
@@ -169,6 +231,26 @@ describe('checkSysInfo', () => {
     const noModel = await checkSysInfo(tmpDir);
     expect(noModel.status).toBe('fail');
     expect(typeof noModel.details?.suggestion).toBe('string');
+  });
+
+  it('includes checksumNote for hash72 devices', async () => {
+    createIpodStructure(tmpDir);
+    writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml({ serialNumber: '5U828071VYY' }));
+    // Pass USB info for nano 5G (0x120c) which is hash72
+    const result = await checkSysInfo(tmpDir, { productId: '0x120c', vendorId: '0x05ac' });
+    // SysInfoExtended present → pass, but should have checksumNote
+    // checksumType derived from USB productId 0x120c → nano_5g → hash72
+    expect(result.details?.checksumNote).toBeDefined();
+    expect(result.details?.checksumNote).toContain('iTunes sync');
+  });
+
+  it('includes checksumNote for hashAB devices via USB productId', async () => {
+    createIpodStructure(tmpDir);
+    writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
+    // Pass USB info for touch 4G (0x129a) which is hashAB
+    const result = await checkSysInfo(tmpDir, { productId: '0x129a', vendorId: '0x05ac' });
+    expect(result.details?.checksumNote).toBeDefined();
+    expect(result.details?.checksumNote).toContain('proprietary');
   });
 });
 
@@ -310,7 +392,7 @@ describe('checkReadiness', () => {
   });
 
   describe('SysInfo behavior', () => {
-    it('fails for missing SysInfo but continues to database check (non-blocking)', async () => {
+    it('fails for missing SysInfo and SysInfoExtended but continues to database check (non-blocking)', async () => {
       createIpodStructure(tmpDir);
       const device = createDevice({ mountPoint: tmpDir });
       const result = await checkReadiness({ device });
@@ -345,12 +427,33 @@ describe('checkReadiness', () => {
       expect(sysinfo?.summary).toContain('XX999');
     });
 
-    it('SysInfo fail and database pass produces needs-repair level', async () => {
+    it('warns for SysInfo with known model but missing SysInfoExtended (no-checksum device)', async () => {
       createIpodStructure(tmpDir);
-      // No SysInfo → sysinfo fail
-      // No database → database fail (needs-init takes priority)
-      // So write a corrupt SysInfo but let the database stage fail as not-found
-      // To test needs-repair: we need sysinfo fail + database fail(corrupt)
+      // MA147 = iPod Video 5th gen = checksumType 'none'
+      writeSysInfo(tmpDir, 'ModelNumStr: MA147\nFirewireGuid: 0001234');
+      const device = createDevice({ mountPoint: tmpDir });
+      const result = await checkReadiness({ device });
+
+      const sysinfo = result.stages.find((s) => s.stage === 'sysinfo');
+      expect(sysinfo?.status).toBe('warn');
+      expect(sysinfo?.summary).toContain('MA147');
+    });
+
+    it('passes when SysInfoExtended is present', async () => {
+      createIpodStructure(tmpDir);
+      writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
+      const device = createDevice({ mountPoint: tmpDir });
+      const result = await checkReadiness({ device });
+
+      const sysinfo = result.stages.find((s) => s.stage === 'sysinfo');
+      expect(sysinfo?.status).toBe('pass');
+      expect(sysinfo?.summary).toContain('SysInfoExtended');
+    });
+
+    it('SysInfo fail and database fail(corrupt) produces needs-repair level', async () => {
+      createIpodStructure(tmpDir);
+      // No SysInfo or SysInfoExtended → sysinfo fail
+      // Corrupt database → database fail
       const dbPath = path.join(tmpDir, 'iPod_Control', 'iTunes', 'iTunesDB');
       fs.writeFileSync(dbPath, 'not a valid database');
       const device = createDevice({ mountPoint: tmpDir });
@@ -393,10 +496,12 @@ describe('checkReadiness', () => {
     });
 
     it('checkSysInfo is callable independently', async () => {
+      // MC297 = iPod Classic 7th gen — without SysInfoExtended this warns (no-checksum: unknown without USB info)
       writeSysInfo(tmpDir, 'ModelNumStr: MC297');
       const result = await checkSysInfo(tmpDir);
       expect(result.stage).toBe('sysinfo');
-      expect(result.status).toBe('pass');
+      // SysInfo present without SysInfoExtended → warn (no USB info to determine checksum severity)
+      expect(result.status).toBe('warn');
       expect(result.summary).toContain('MC297');
       expect(result.details?.modelNumber).toBe('MC297');
     });

--- a/packages/podkit-core/src/device/readiness.test.ts
+++ b/packages/podkit-core/src/device/readiness.test.ts
@@ -147,7 +147,7 @@ describe('checkSysInfo', () => {
     expect(result.details?.modelNumber).toBe('MA147');
     expect(result.details?.modelName).toBeTruthy();
     expect(result.details?.sysInfoExtendedExists).toBe(false);
-    expect(result.details?.suggestion).toContain('SysInfoExtended missing');
+    expect(result.details?.suggestion).toContain('--repair sysinfo-extended');
   });
 
   it('fails when SysInfo has known model but SysInfoExtended is missing (hash58 device)', async () => {

--- a/packages/podkit-core/src/device/readiness.test.ts
+++ b/packages/podkit-core/src/device/readiness.test.ts
@@ -135,11 +135,13 @@ describe('checkSysInfo', () => {
     expect(result.summary).toContain('SysInfoExtended');
   });
 
-  it('warns when SysInfo has known model but SysInfoExtended is missing (no-checksum device)', async () => {
-    // MA147 = iPod Video 5th gen = checksumType 'none'
+  it('passes with advisory when SysInfo has known model but SysInfoExtended is missing (no-checksum device)', async () => {
+    // MA147 = iPod Video 5th gen = checksumType 'none'.
+    // Classic SysInfo is sufficient — SysInfoExtended is optional richer
+    // identity metadata. Absence is surfaced via details, not a warn.
     writeSysInfo(tmpDir, 'ModelNumStr: MA147\nFirewireGuid: 0001234');
     const result = await checkSysInfo(tmpDir);
-    expect(result.status).toBe('warn');
+    expect(result.status).toBe('pass');
     expect(result.summary).toContain('MA147');
     expect(result.summary).toContain('iPod Video');
     expect(result.details?.modelNumber).toBe('MA147');
@@ -427,15 +429,16 @@ describe('checkReadiness', () => {
       expect(sysinfo?.summary).toContain('XX999');
     });
 
-    it('warns for SysInfo with known model but missing SysInfoExtended (no-checksum device)', async () => {
+    it('passes for SysInfo with known model but missing SysInfoExtended (no-checksum device)', async () => {
       createIpodStructure(tmpDir);
-      // MA147 = iPod Video 5th gen = checksumType 'none'
+      // MA147 = iPod Video 5th gen = checksumType 'none'.
+      // SysInfoExtended is optional for non-hash devices.
       writeSysInfo(tmpDir, 'ModelNumStr: MA147\nFirewireGuid: 0001234');
       const device = createDevice({ mountPoint: tmpDir });
       const result = await checkReadiness({ device });
 
       const sysinfo = result.stages.find((s) => s.stage === 'sysinfo');
-      expect(sysinfo?.status).toBe('warn');
+      expect(sysinfo?.status).toBe('pass');
       expect(sysinfo?.summary).toContain('MA147');
     });
 
@@ -496,12 +499,12 @@ describe('checkReadiness', () => {
     });
 
     it('checkSysInfo is callable independently', async () => {
-      // MC297 = iPod Classic 7th gen — without SysInfoExtended this warns (no-checksum: unknown without USB info)
+      // MC297 = iPod Classic 7th gen. Without USB info we can't tell the
+      // checksum severity, so we treat SysInfoExtended as optional → pass.
       writeSysInfo(tmpDir, 'ModelNumStr: MC297');
       const result = await checkSysInfo(tmpDir);
       expect(result.stage).toBe('sysinfo');
-      // SysInfo present without SysInfoExtended → warn (no USB info to determine checksum severity)
-      expect(result.status).toBe('warn');
+      expect(result.status).toBe('pass');
       expect(result.summary).toContain('MC297');
       expect(result.details?.modelNumber).toBe('MC297');
     });

--- a/packages/podkit-core/src/device/readiness.test.ts
+++ b/packages/podkit-core/src/device/readiness.test.ts
@@ -120,7 +120,6 @@ describe('checkSysInfo', () => {
     writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
     const result = await checkSysInfo(tmpDir);
     expect(result.status).toBe('pass');
-    expect(result.summary).toContain('SysInfoExtended');
     expect(result.details?.sysInfoExtendedExists).toBe(true);
     expect(result.details?.firewireGuid).toBeTruthy();
     expect(result.details?.serialNumber).toBeTruthy();
@@ -132,7 +131,7 @@ describe('checkSysInfo', () => {
     writeSysInfoExtended(tmpDir, makeSysInfoExtendedXml());
     const result = await checkSysInfo(tmpDir);
     expect(result.status).toBe('pass');
-    expect(result.summary).toContain('SysInfoExtended');
+    expect(result.details?.sysInfoExtendedExists).toBe(true);
   });
 
   it('passes with advisory when SysInfo has known model but SysInfoExtended is missing (no-checksum device)', async () => {
@@ -450,7 +449,7 @@ describe('checkReadiness', () => {
 
       const sysinfo = result.stages.find((s) => s.stage === 'sysinfo');
       expect(sysinfo?.status).toBe('pass');
-      expect(sysinfo?.summary).toContain('SysInfoExtended');
+      expect(sysinfo?.details?.sysInfoExtendedExists).toBe(true);
     });
 
     it('SysInfo fail and database fail(corrupt) produces needs-repair level', async () => {

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -1,12 +1,18 @@
 import * as fs from 'node:fs';
 import { join } from 'node:path';
 import type { PlatformDeviceInfo } from './types.js';
-import type { DeviceAssessment } from './assessment.js';
+import type { DeviceAssessment, UsbDeviceInfo } from './assessment.js';
 import type { UsbDiscoveredDevice } from './usb-discovery.js';
 import { IpodDatabase } from '../ipod/database.js';
 import { IpodError } from '../ipod/errors.js';
 import { interpretError } from './error-codes.js';
-import { lookupIpodModelByNumber } from './ipod-models.js';
+import {
+  lookupIpodModelByNumber,
+  lookupGenerationByProductId,
+  getChecksumType,
+} from './ipod-models.js';
+import type { IpodChecksumType } from './ipod-models.js';
+import { readSysInfoExtended } from './sysinfo-extended.js';
 
 // ── Stage identifiers ────────────────────────────────────────────────────────
 
@@ -48,6 +54,7 @@ export interface ReadinessResult {
 export interface ReadinessInput {
   device: PlatformDeviceInfo;
   assessment?: DeviceAssessment;
+  usbInfo?: UsbDeviceInfo;
 }
 
 // ── Stage display names ───────────────────────────────────────────────────────
@@ -148,10 +155,59 @@ function isBinaryContent(buf: Buffer): boolean {
   return false;
 }
 
-export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageResult> {
+export async function checkSysInfo(
+  mountPoint: string,
+  usbInfo?: UsbDeviceInfo
+): Promise<ReadinessStageResult> {
   const sysInfoPath = join(mountPoint, 'iPod_Control', 'Device', 'SysInfo');
+  const sysInfoExtendedPath = join(mountPoint, 'iPod_Control', 'Device', 'SysInfoExtended');
 
-  // Check existence
+  // ── Step 1: Check SysInfoExtended ──────────────────────────────────────
+  const sysInfoExtended = readSysInfoExtended(mountPoint);
+  const sysInfoExtendedExists = sysInfoExtended !== null;
+
+  // Determine checksum type from USB product ID or SysInfoExtended serial
+  let checksumType: IpodChecksumType | undefined;
+  if (usbInfo?.productId) {
+    const gen = lookupGenerationByProductId(usbInfo.productId);
+    if (gen) checksumType = getChecksumType(gen);
+  }
+  if (!checksumType && sysInfoExtended?.deviceInfo?.checksumType) {
+    checksumType = sysInfoExtended.deviceInfo.checksumType as IpodChecksumType;
+  }
+
+  // Build limitation note for hash72/hashAB devices
+  let checksumNote: string | undefined;
+  if (checksumType === 'hash72') {
+    checksumNote = 'This device requires an initial iTunes sync for HashInfo bootstrapping';
+  } else if (checksumType === 'hashAB') {
+    checksumNote = 'This device requires proprietary components not available in podkit';
+  }
+
+  // ── Step 2: If SysInfoExtended is present, use it ────────────────────
+  if (sysInfoExtendedExists && sysInfoExtended.deviceInfo) {
+    const info = sysInfoExtended.deviceInfo;
+    const displayName = info.modelName ?? 'Unknown iPod';
+    return {
+      stage: 'sysinfo',
+      status: 'pass',
+      summary: `${displayName} (SysInfoExtended)`,
+      details: {
+        sysInfoPath,
+        sysInfoExtendedPath,
+        exists: true,
+        sysInfoExtendedExists: true,
+        hasModelNum: true,
+        modelName: info.modelName,
+        firewireGuid: info.firewireGuid,
+        serialNumber: info.serialNumber,
+        checksumType: info.checksumType ?? checksumType,
+        ...(checksumNote ? { checksumNote } : {}),
+      },
+    };
+  }
+
+  // ── Step 3: Check SysInfo (classic file) ─────────────────────────────
   let fileExists = false;
   try {
     fs.accessSync(sysInfoPath, fs.constants.F_OK);
@@ -161,14 +217,21 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
   }
 
   if (!fileExists) {
+    // Both missing → fail
+    const suggestion =
+      'Run `podkit doctor --repair sysinfo-extended` to read device identity from USB.';
     return {
       stage: 'sysinfo',
       status: 'fail',
-      summary: 'SysInfo file not found',
+      summary: 'SysInfo and SysInfoExtended not found',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: false,
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        sysInfoExtendedExists: false,
+        hasModelNum: false,
+        checksumType,
+        suggestion,
       },
     };
   }
@@ -184,7 +247,9 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: 'SysInfo file could not be read',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         error: error instanceof Error ? error.message : String(error),
         suggestion: SYSINFO_SUGGESTION_RESET,
       },
@@ -199,7 +264,9 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: 'SysInfo file is empty',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         suggestion: SYSINFO_SUGGESTION_RESET,
       },
     };
@@ -213,7 +280,9 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: 'SysInfo file appears to be binary/corrupt',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         suggestion: SYSINFO_SUGGESTION_RESET,
       },
     };
@@ -230,7 +299,9 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: 'SysInfo file contains invalid UTF-8',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         suggestion: SYSINFO_SUGGESTION_RESET,
       },
     };
@@ -245,7 +316,9 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: 'SysInfo exists but ModelNumStr not found',
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         hasModelNum: false,
         suggestion: SYSINFO_SUGGESTION_RESET,
       },
@@ -262,20 +335,61 @@ export async function checkSysInfo(mountPoint: string): Promise<ReadinessStageRe
       summary: `Unrecognized model: ${modelNumber}`,
       details: {
         sysInfoPath,
+        sysInfoExtendedPath,
         exists: true,
+        sysInfoExtendedExists: false,
         hasModelNum: true,
         modelNumber,
+        checksumType,
         suggestion:
           'Device will be treated as a generic iPod. This is usually fine but may affect artwork format detection.',
       },
     };
   }
 
+  // ── Step 4: SysInfo present but SysInfoExtended missing ────────────────
+  // Determine severity based on checksum type
+  const needsChecksumSysInfoExtended =
+    checksumType === 'hash58' || checksumType === 'hash72' || checksumType === 'hashAB';
+
+  if (needsChecksumSysInfoExtended) {
+    // Hash-requiring devices FAIL without SysInfoExtended
+    return {
+      stage: 'sysinfo',
+      status: 'fail',
+      summary: `${modelName} (${modelNumber}) — SysInfoExtended required for checksum`,
+      details: {
+        sysInfoPath,
+        sysInfoExtendedPath,
+        exists: true,
+        sysInfoExtendedExists: false,
+        hasModelNum: true,
+        modelNumber,
+        modelName,
+        checksumType,
+        ...(checksumNote ? { checksumNote } : {}),
+        suggestion: 'Run `podkit doctor --repair sysinfo-extended` for full device identification.',
+      },
+    };
+  }
+
+  // Non-checksum devices WARN — SysInfoExtended is nice to have
   return {
     stage: 'sysinfo',
-    status: 'pass',
+    status: 'warn',
     summary: `${modelName} (${modelNumber})`,
-    details: { sysInfoPath, exists: true, hasModelNum: true, modelNumber, modelName },
+    details: {
+      sysInfoPath,
+      sysInfoExtendedPath,
+      exists: true,
+      sysInfoExtendedExists: false,
+      hasModelNum: true,
+      modelNumber,
+      modelName,
+      checksumType,
+      suggestion:
+        'SysInfo present but SysInfoExtended missing. Run `podkit doctor --repair sysinfo-extended` for full device identification.',
+    },
   };
 }
 
@@ -483,7 +597,7 @@ export async function checkReadiness(input: ReadinessInput): Promise<ReadinessRe
 
   // Stage 5: Valid SysInfo
   try {
-    const sysInfoResult = await checkSysInfo(device.mountPoint);
+    const sysInfoResult = await checkSysInfo(device.mountPoint, input.usbInfo);
     stages.push(sysInfoResult);
     // SysInfo warns but doesn't block — continue to database
   } catch (error) {

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -195,7 +195,9 @@ export async function checkSysInfo(
     return {
       stage: 'sysinfo',
       status: 'pass',
-      summary: `${displayName} (SysInfoExtended)`,
+      // SysInfoExtended-present is surfaced separately by the renderer via
+      // details.sysInfoExtendedExists, so the summary stays model-only.
+      summary: displayName,
       details: {
         sysInfoPath,
         sysInfoExtendedPath,

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -139,8 +139,12 @@ export async function checkIpodStructure(mountPoint: string): Promise<ReadinessS
   };
 }
 
-const SYSINFO_SUGGESTION_RESET =
-  'Run `podkit device reset` to recreate, or manually create iPod_Control/Device/SysInfo with your model number.';
+// Non-destructive repair hint for any sysinfo-stage failure: read identity
+// from USB firmware and write SysInfoExtended. libgpod prefers
+// SysInfoExtended over classic SysInfo, so this fixes missing/empty/corrupt
+// SysInfo files without resetting the device or touching user data.
+const SYSINFO_SUGGESTION_REPAIR =
+  'Run `podkit doctor --repair sysinfo-extended` to read device identity from USB.';
 
 /** Returns true if the buffer contains control characters that indicate binary content. */
 function isBinaryContent(buf: Buffer): boolean {
@@ -218,8 +222,6 @@ export async function checkSysInfo(
 
   if (!fileExists) {
     // Both missing → fail
-    const suggestion =
-      'Run `podkit doctor --repair sysinfo-extended` to read device identity from USB.';
     return {
       stage: 'sysinfo',
       status: 'fail',
@@ -231,7 +233,7 @@ export async function checkSysInfo(
         sysInfoExtendedExists: false,
         hasModelNum: false,
         checksumType,
-        suggestion,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -251,7 +253,7 @@ export async function checkSysInfo(
         exists: true,
         sysInfoExtendedExists: false,
         error: error instanceof Error ? error.message : String(error),
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -267,7 +269,7 @@ export async function checkSysInfo(
         sysInfoExtendedPath,
         exists: true,
         sysInfoExtendedExists: false,
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -283,7 +285,7 @@ export async function checkSysInfo(
         sysInfoExtendedPath,
         exists: true,
         sysInfoExtendedExists: false,
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -302,7 +304,7 @@ export async function checkSysInfo(
         sysInfoExtendedPath,
         exists: true,
         sysInfoExtendedExists: false,
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -320,7 +322,7 @@ export async function checkSysInfo(
         exists: true,
         sysInfoExtendedExists: false,
         hasModelNum: false,
-        suggestion: SYSINFO_SUGGESTION_RESET,
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -368,7 +370,7 @@ export async function checkSysInfo(
         modelName,
         checksumType,
         ...(checksumNote ? { checksumNote } : {}),
-        suggestion: 'Run `podkit doctor --repair sysinfo-extended` for full device identification.',
+        suggestion: SYSINFO_SUGGESTION_REPAIR,
       },
     };
   }
@@ -390,8 +392,7 @@ export async function checkSysInfo(
       modelNumber,
       modelName,
       checksumType,
-      suggestion:
-        'SysInfo present but SysInfoExtended missing. Run `podkit doctor --repair sysinfo-extended` for full device identification.',
+      suggestion: SYSINFO_SUGGESTION_REPAIR,
     },
   };
 }

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -535,8 +535,11 @@ const READINESS_RULES: ReadinessRule[] = [
     level: 'needs-repair',
   },
   {
-    description: 'All stages passed — device is ready',
-    match: (stages) => stages.get('database')?.status === 'pass',
+    description: 'All stages passed or warned — device is ready',
+    match: (stages) => {
+      const db = stages.get('database')?.status;
+      return db === 'pass' || db === 'warn';
+    },
     level: 'ready',
   },
 ];

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -373,10 +373,13 @@ export async function checkSysInfo(
     };
   }
 
-  // Non-checksum devices WARN — SysInfoExtended is nice to have
+  // Non-checksum devices: classic SysInfo is sufficient. SysInfoExtended is
+  // optional richer-identity metadata. Surface absence in details so verbose
+  // output can show the `--repair sysinfo-extended` suggestion, but don't
+  // warn — that would flag every dummy fixture and freshly-reset iPod.
   return {
     stage: 'sysinfo',
-    status: 'warn',
+    status: 'pass',
     summary: `${modelName} (${modelNumber})`,
     details: {
       sysInfoPath,

--- a/packages/podkit-core/src/device/readiness.ts
+++ b/packages/podkit-core/src/device/readiness.ts
@@ -457,61 +457,96 @@ function skipRemaining(stages: ReadinessStageResult[], fromIndex: number): void 
   }
 }
 
+interface ReadinessRule {
+  /** Human-readable description for maintainability */
+  description: string;
+  /** Returns true if this rule matches the given stage results */
+  match: (stages: Map<ReadinessStage, ReadinessStageResult>) => boolean;
+  /** The readiness level to return when matched */
+  level: ReadinessLevel;
+}
+
+const READINESS_RULES: ReadinessRule[] = [
+  {
+    description: 'I/O error in any stage',
+    match: (stages) =>
+      [...stages.values()].some(
+        (s) =>
+          typeof s.details?.error === 'string' &&
+          /i\/o error|input\/output error/i.test(s.details.error as string)
+      ),
+    level: 'hardware-error',
+  },
+  {
+    description: 'USB detection failed',
+    match: (stages) => stages.get('usb')?.status === 'fail',
+    level: 'hardware-error',
+  },
+  {
+    description: 'Partition check failed',
+    match: (stages) => stages.get('partition')?.status === 'fail',
+    level: 'needs-partition',
+  },
+  {
+    description: 'Filesystem check failed',
+    match: (stages) => stages.get('filesystem')?.status === 'fail',
+    level: 'needs-format',
+  },
+  {
+    description: 'Mount failed — no iPod_Control directory',
+    match: (stages) => {
+      const mount = stages.get('mount');
+      return mount?.status === 'fail' && mount.details?.ipodControlExists === false;
+    },
+    level: 'needs-init',
+  },
+  {
+    description: 'Mount failed — stale mount or OS error (mountPoint/errno present)',
+    match: (stages) => {
+      const mount = stages.get('mount');
+      return (
+        mount?.status === 'fail' &&
+        (mount.details?.mountPoint !== undefined || mount.details?.errno !== undefined)
+      );
+    },
+    level: 'hardware-error',
+  },
+  {
+    description: 'Mount failed — unmounted device (fallback)',
+    match: (stages) => stages.get('mount')?.status === 'fail',
+    level: 'needs-init',
+  },
+  {
+    description: 'Database failed — does not exist',
+    match: (stages) => {
+      const db = stages.get('database');
+      return db?.status === 'fail' && db.details?.exists === false;
+    },
+    level: 'needs-init',
+  },
+  {
+    description: 'Database failed — exists but corrupt',
+    match: (stages) => stages.get('database')?.status === 'fail',
+    level: 'needs-repair',
+  },
+  {
+    description: 'SysInfo check failed',
+    match: (stages) => stages.get('sysinfo')?.status === 'fail',
+    level: 'needs-repair',
+  },
+  {
+    description: 'All stages passed — device is ready',
+    match: (stages) => stages.get('database')?.status === 'pass',
+    level: 'ready',
+  },
+];
+
 function determineLevel(stages: ReadinessStageResult[]): ReadinessLevel {
   const byStage = new Map(stages.map((s) => [s.stage, s]));
 
-  // Check for hardware errors (IO errors during any stage)
-  for (const s of stages) {
-    if (s.details?.error && typeof s.details.error === 'string') {
-      const err = s.details.error.toLowerCase();
-      if (err.includes('i/o error') || err.includes('input/output error')) {
-        return 'hardware-error';
-      }
-    }
+  for (const rule of READINESS_RULES) {
+    if (rule.match(byStage)) return rule.level;
   }
-
-  const usb = byStage.get('usb');
-  const partition = byStage.get('partition');
-  const filesystem = byStage.get('filesystem');
-  const mount = byStage.get('mount');
-  const sysinfo = byStage.get('sysinfo');
-  const database = byStage.get('database');
-
-  // USB failed → hardware-error
-  if (usb?.status === 'fail') return 'hardware-error';
-
-  // Partitioned failed → needs-partition
-  if (partition?.status === 'fail') return 'needs-partition';
-
-  // Filesystem failed → needs-format
-  if (filesystem?.status === 'fail') return 'needs-format';
-
-  // Mount failed → check why
-  if (mount?.status === 'fail') {
-    // No iPod_Control → needs-init
-    if (mount.details?.ipodControlExists === false) return 'needs-init';
-    // Stale mount or OS error — statfs failed or other low-level mount failure
-    if (mount.details?.mountPoint !== undefined || mount.details?.errno !== undefined) {
-      return 'hardware-error';
-    }
-    // Unmounted device (details: { isMounted: false }) — no iPod_Control check was performed
-    return 'needs-init';
-  }
-
-  // Mount passed (or warned). Check SysInfo and Database.
-  // Database doesn't exist → needs-init
-  if (database?.status === 'fail') {
-    if (database.details?.exists === false) return 'needs-init';
-    // DB exists but corrupt → needs-repair
-    return 'needs-repair';
-  }
-
-  // SysInfo problems with database OK → needs-repair (warn level, won't actually fail pipeline)
-  // But if sysinfo warns and database passes, that's still ready
-  if (sysinfo?.status === 'fail') return 'needs-repair';
-
-  // All pass or warn → ready
-  if (database?.status === 'pass') return 'ready';
 
   return 'unknown';
 }

--- a/packages/podkit-core/src/device/sysinfo-extended.test.ts
+++ b/packages/podkit-core/src/device/sysinfo-extended.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  ensureSysInfoExtended,
+  readSysInfoExtended,
+  type ReadFromUsbFn,
+} from './sysinfo-extended.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Realistic SysInfoExtended XML based on iPod Nano 3G data */
+const FIXTURE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FireWireGUID</key>
+	<string>000A27001DCECFB5</string>
+	<key>SerialNumber</key>
+	<string>5U828GFNYXX</string>
+	<key>FamilyID</key>
+	<integer>10</integer>
+	<key>DBVersion</key>
+	<integer>3</integer>
+	<key>ModelNumber</key>
+	<string>B261</string>
+	<key>UpdaterFamilyID</key>
+	<integer>10</integer>
+	<key>BoardHwSwInterfaceRev</key>
+	<integer>65536</integer>
+	<key>VisibleBuildID</key>
+	<string>1.1.3 (3.1.1)</string>
+</dict>
+</plist>`;
+
+/** XML missing FireWireGUID */
+const FIXTURE_XML_NO_GUID = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>SerialNumber</key>
+	<string>5U828GFNYXX</string>
+</dict>
+</plist>`;
+
+/** XML missing SerialNumber */
+const FIXTURE_XML_NO_SERIAL = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>FireWireGUID</key>
+	<string>000A27001DCECFB5</string>
+</dict>
+</plist>`;
+
+/** XML with alternate FirewireGuid casing */
+const FIXTURE_XML_ALT_CASING = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>FirewireGuid</key>
+	<string>000A27001DCECFB5</string>
+	<key>SerialNumber</key>
+	<string>5U828GFNYXX</string>
+</dict>
+</plist>`;
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'podkit-sysinfo-ext-'));
+}
+
+function createIpodStructure(mountPoint: string): void {
+  fs.mkdirSync(path.join(mountPoint, 'iPod_Control', 'Device'), {
+    recursive: true,
+  });
+}
+
+function writeSysInfoExtended(mountPoint: string, content: string): void {
+  const deviceDir = path.join(mountPoint, 'iPod_Control', 'Device');
+  fs.mkdirSync(deviceDir, { recursive: true });
+  fs.writeFileSync(path.join(deviceDir, 'SysInfoExtended'), content, 'utf-8');
+}
+
+const USB_ADDRESS = { busNumber: 1, deviceAddress: 4 };
+
+// ── readSysInfoExtended ─────────────────────────────────────────────────────
+
+describe('readSysInfoExtended', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('parses existing SysInfoExtended and extracts device info', () => {
+    writeSysInfoExtended(tmpDir, FIXTURE_XML);
+    const result = readSysInfoExtended(tmpDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.present).toBe(true);
+    expect(result!.source).toBe('existing');
+    expect(result!.deviceInfo).toBeDefined();
+    expect(result!.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+    expect(result!.deviceInfo!.serialNumber).toBe('5U828GFNYXX');
+  });
+
+  it('returns null when file does not exist', () => {
+    createIpodStructure(tmpDir);
+    const result = readSysInfoExtended(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when file is empty', () => {
+    writeSysInfoExtended(tmpDir, '');
+    const result = readSysInfoExtended(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when file is whitespace-only', () => {
+    writeSysInfoExtended(tmpDir, '   \n  \n  ');
+    const result = readSysInfoExtended(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('returns result with no deviceInfo when XML lacks required keys', () => {
+    writeSysInfoExtended(tmpDir, FIXTURE_XML_NO_GUID);
+    const result = readSysInfoExtended(tmpDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.present).toBe(true);
+    expect(result!.source).toBe('existing');
+    // deviceInfo is undefined because FireWireGUID is missing
+    expect(result!.deviceInfo).toBeUndefined();
+  });
+
+  it('handles alternate FirewireGuid casing', () => {
+    writeSysInfoExtended(tmpDir, FIXTURE_XML_ALT_CASING);
+    const result = readSysInfoExtended(tmpDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.deviceInfo).toBeDefined();
+    expect(result!.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+  });
+
+  it('looks up model from serial suffix', () => {
+    writeSysInfoExtended(tmpDir, FIXTURE_XML);
+    const result = readSysInfoExtended(tmpDir);
+
+    expect(result!.deviceInfo!.modelName).toBeDefined();
+    // Serial "5U828GFNYXX" -> suffix "YXX" -> iPod nano 3rd Gen
+    expect(result!.deviceInfo!.modelName).toContain('nano');
+    expect(result!.deviceInfo!.modelName).toContain('3rd Generation');
+    expect(result!.deviceInfo!.generationId).toBe('nano_3g');
+    expect(result!.deviceInfo!.checksumType).toBeDefined();
+  });
+
+  it('returns deviceInfo without model fields for unknown serial suffix', () => {
+    const xml = FIXTURE_XML.replace('5U828GFNYXX', 'UNKNOWNZZZ');
+    writeSysInfoExtended(tmpDir, xml);
+
+    const result = readSysInfoExtended(tmpDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.deviceInfo).toBeDefined();
+    expect(result!.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+    expect(result!.deviceInfo!.serialNumber).toBe('UNKNOWNZZZ');
+    expect(result!.deviceInfo!.modelName).toBeUndefined();
+    expect(result!.deviceInfo!.generationId).toBeUndefined();
+    expect(result!.deviceInfo!.checksumType).toBeUndefined();
+  });
+});
+
+// ── ensureSysInfoExtended ───────────────────────────────────────────────────
+
+describe('ensureSysInfoExtended', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns existing file without calling USB read', async () => {
+    writeSysInfoExtended(tmpDir, FIXTURE_XML);
+
+    let usbReadCalled = false;
+    const mockReader: ReadFromUsbFn = () => {
+      usbReadCalled = true;
+      return FIXTURE_XML;
+    };
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(true);
+    expect(result.source).toBe('existing');
+    expect(result.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+    expect(usbReadCalled).toBe(false);
+  });
+
+  it('reads from USB and writes to disk when file is missing', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(true);
+    expect(result.source).toBe('usb-read');
+    expect(result.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+    expect(result.deviceInfo!.serialNumber).toBe('5U828GFNYXX');
+
+    // Verify file was written
+    const filePath = path.join(tmpDir, 'iPod_Control', 'Device', 'SysInfoExtended');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const written = fs.readFileSync(filePath, 'utf-8');
+    expect(written).toBe(FIXTURE_XML);
+  });
+
+  it('returns unavailable when USB read returns null', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => null;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(false);
+    expect(result.source).toBe('unavailable');
+    expect(result.error).toBe('Could not read device identity from USB');
+  });
+
+  it('returns unavailable when no reader is provided and native is unavailable', async () => {
+    createIpodStructure(tmpDir);
+
+    // Pass no readFromUsb — the default resolver will fail in test env
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS);
+
+    expect(result.present).toBe(false);
+    expect(result.source).toBe('unavailable');
+    expect(result.error).toContain('not available');
+  });
+
+  it('validates XML and rejects missing FireWireGUID', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML_NO_GUID;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(false);
+    expect(result.source).toBe('unavailable');
+    expect(result.error).toBe('Device returned incomplete identity data');
+
+    // Verify file was NOT written
+    const filePath = path.join(tmpDir, 'iPod_Control', 'Device', 'SysInfoExtended');
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it('validates XML and rejects missing SerialNumber', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML_NO_SERIAL;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(false);
+    expect(result.source).toBe('unavailable');
+    expect(result.error).toBe('Device returned incomplete identity data');
+  });
+
+  it('creates Device directory when it does not exist', async () => {
+    // Only create iPod_Control, not Device subdirectory
+    fs.mkdirSync(path.join(tmpDir, 'iPod_Control'), { recursive: true });
+
+    const deviceDir = path.join(tmpDir, 'iPod_Control', 'Device');
+    expect(fs.existsSync(deviceDir)).toBe(false);
+
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML;
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(true);
+    expect(result.source).toBe('usb-read');
+    expect(fs.existsSync(deviceDir)).toBe(true);
+
+    const filePath = path.join(deviceDir, 'SysInfoExtended');
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  it('extracts model info from serial suffix', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.deviceInfo).toBeDefined();
+    // Serial "5U828GFNYXX" -> suffix "YXX" -> nano 3G
+    expect(result.deviceInfo!.modelName).toContain('nano');
+    expect(result.deviceInfo!.modelName).toContain('3rd Generation');
+    expect(result.deviceInfo!.generationId).toBe('nano_3g');
+    expect(result.deviceInfo!.checksumType).toBeDefined();
+  });
+
+  it('handles alternate FirewireGuid casing in USB-read XML', async () => {
+    createIpodStructure(tmpDir);
+    const mockReader: ReadFromUsbFn = () => FIXTURE_XML_ALT_CASING;
+
+    const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS, mockReader);
+
+    expect(result.present).toBe(true);
+    expect(result.source).toBe('usb-read');
+    expect(result.deviceInfo!.firewireGuid).toBe('000A27001DCECFB5');
+  });
+});

--- a/packages/podkit-core/src/device/sysinfo-extended.test.ts
+++ b/packages/podkit-core/src/device/sysinfo-extended.test.ts
@@ -233,15 +233,17 @@ describe('ensureSysInfoExtended', () => {
     expect(result.error).toBe('Could not read device identity from USB');
   });
 
-  it('returns unavailable when no reader is provided and native is unavailable', async () => {
+  it('returns unavailable when no reader is provided and USB read fails', async () => {
     createIpodStructure(tmpDir);
 
-    // Pass no readFromUsb — the default resolver will fail in test env
+    // Pass no readFromUsb — uses default resolver. With native available,
+    // the real function runs but returns null for invalid bus/address.
+    // Without native, the import fails and returns null reader.
+    // Either way: result is unavailable.
     const result = await ensureSysInfoExtended(tmpDir, USB_ADDRESS);
 
     expect(result.present).toBe(false);
     expect(result.source).toBe('unavailable');
-    expect(result.error).toContain('not available');
   });
 
   it('validates XML and rejects missing FireWireGUID', async () => {

--- a/packages/podkit-core/src/device/sysinfo-extended.ts
+++ b/packages/podkit-core/src/device/sysinfo-extended.ts
@@ -1,0 +1,233 @@
+/**
+ * SysInfoExtended orchestrator.
+ *
+ * Coordinates reading SysInfoExtended from iPod firmware via USB and writing
+ * it to the device filesystem. Also parses existing SysInfoExtended files
+ * to extract device identity information.
+ *
+ * SysInfoExtended is an Apple plist XML file stored at
+ * `iPod_Control/Device/SysInfoExtended` on the iPod filesystem. It contains
+ * device identity fields (FireWireGUID, SerialNumber, FamilyID, etc.) that
+ * are needed for proper database initialization and checksum generation.
+ */
+
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { lookupIpodModelBySerial, getChecksumType } from './ipod-models.js';
+import type { IpodGenerationId } from './ipod-models.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+/** Result of attempting to ensure SysInfoExtended is present */
+export interface SysInfoExtendedResult {
+  /** Whether SysInfoExtended is now present on the device */
+  present: boolean;
+  /** How the result was obtained */
+  source: 'existing' | 'usb-read' | 'unavailable';
+  /** Extracted device identity (when present) */
+  deviceInfo?: {
+    firewireGuid: string;
+    serialNumber: string;
+    modelName?: string;
+    generationId?: IpodGenerationId;
+    checksumType?: 'none' | 'hash58' | 'hash72' | 'hashAB';
+  };
+  /** Error message when source is 'unavailable' */
+  error?: string;
+}
+
+/** USB device addressing for SysInfoExtended reads */
+export interface UsbDeviceAddress {
+  busNumber: number;
+  deviceAddress: number;
+}
+
+/** Function signature for reading SysInfoExtended from USB (for dependency injection in tests) */
+export type ReadFromUsbFn = (busNumber: number, deviceAddress: number) => string | null;
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const SYSINFO_EXTENDED_PATH = join('iPod_Control', 'Device', 'SysInfoExtended');
+const DEVICE_DIR = join('iPod_Control', 'Device');
+
+// ── XML extraction ──────────────────────────────────────────────────────────
+
+/**
+ * Extract a string value from plist XML by key name.
+ * Handles `<key>Name</key>\s*<string>Value</string>` patterns.
+ */
+function extractPlistString(xml: string, key: string): string | undefined {
+  const pattern = new RegExp(`<key>${key}</key>\\s*<string>([^<]+)</string>`, 'i');
+  const match = xml.match(pattern);
+  return match?.[1];
+}
+
+/**
+ * Extract device identity fields from SysInfoExtended XML.
+ */
+function extractDeviceInfo(xml: string): SysInfoExtendedResult['deviceInfo'] | undefined {
+  // Try both casing variants for FireWireGUID
+  const firewireGuid =
+    extractPlistString(xml, 'FireWireGUID') ?? extractPlistString(xml, 'FirewireGuid');
+
+  const serialNumber = extractPlistString(xml, 'SerialNumber');
+
+  if (!firewireGuid || !serialNumber) {
+    return undefined;
+  }
+
+  const info: NonNullable<SysInfoExtendedResult['deviceInfo']> = {
+    firewireGuid,
+    serialNumber,
+  };
+
+  // Look up model from last 3 chars of serial number
+  if (serialNumber.length >= 3) {
+    const suffix = serialNumber.slice(-3);
+    const model = lookupIpodModelBySerial(suffix);
+    if (model) {
+      info.modelName = model.displayName;
+      info.generationId = model.generation;
+      info.checksumType = getChecksumType(model.generation as IpodGenerationId);
+    }
+  }
+
+  return info;
+}
+
+/**
+ * Validate that SysInfoExtended XML contains the required identity keys.
+ */
+function validateXml(xml: string): { valid: boolean; error?: string } {
+  const hasFirewireGuid =
+    extractPlistString(xml, 'FireWireGUID') !== undefined ||
+    extractPlistString(xml, 'FirewireGuid') !== undefined;
+  const hasSerial = extractPlistString(xml, 'SerialNumber') !== undefined;
+
+  if (!hasFirewireGuid || !hasSerial) {
+    return {
+      valid: false,
+      error: 'Device returned incomplete identity data',
+    };
+  }
+
+  return { valid: true };
+}
+
+// ── Default USB reader ──────────────────────────────────────────────────────
+
+/**
+ * Create the default USB reader function.
+ * Returns null if native bindings are not available.
+ */
+function getDefaultUsbReader(): ReadFromUsbFn | null {
+  try {
+    // Dynamic import to avoid hard dependency on native bindings
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const libgpod = require('@podkit/libgpod-node');
+    if (typeof libgpod.isNativeAvailable === 'function' && !libgpod.isNativeAvailable()) {
+      return null;
+    }
+    if (typeof libgpod.readSysInfoExtendedFromUsb === 'function') {
+      return libgpod.readSysInfoExtendedFromUsb;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Read and parse an existing SysInfoExtended file from an iPod.
+ * Returns null if file doesn't exist or is empty.
+ *
+ * This is useful for the readiness pipeline to check without triggering a USB read.
+ */
+export function readSysInfoExtended(mountPoint: string): SysInfoExtendedResult | null {
+  const filePath = join(mountPoint, SYSINFO_EXTENDED_PATH);
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  if (!content.trim()) {
+    return null;
+  }
+
+  const deviceInfo = extractDeviceInfo(content);
+  return {
+    present: true,
+    source: 'existing',
+    deviceInfo,
+  };
+}
+
+/**
+ * Ensure SysInfoExtended is present on an iPod's filesystem.
+ *
+ * If already present, reads and parses it. If missing, reads from USB
+ * firmware and writes to disk. Returns extracted device identity info.
+ *
+ * @param mountPoint - iPod mount point (e.g., "/Volumes/iPod")
+ * @param usbAddress - USB bus number and device address
+ * @param readFromUsb - Optional USB reader function (for testing). Defaults to libgpod-node binding.
+ */
+export async function ensureSysInfoExtended(
+  mountPoint: string,
+  usbAddress: UsbDeviceAddress,
+  readFromUsb?: ReadFromUsbFn
+): Promise<SysInfoExtendedResult> {
+  // Step 1: Check if file already exists
+  const existing = readSysInfoExtended(mountPoint);
+  if (existing) {
+    return existing;
+  }
+
+  // Step 2: Resolve USB reader
+  const reader = readFromUsb ?? getDefaultUsbReader();
+  if (!reader) {
+    return {
+      present: false,
+      source: 'unavailable',
+      error: 'Native bindings not available for USB device read',
+    };
+  }
+
+  // Step 3: Read from USB
+  const xml = reader(usbAddress.busNumber, usbAddress.deviceAddress);
+  if (!xml) {
+    return {
+      present: false,
+      source: 'unavailable',
+      error: 'Could not read device identity from USB',
+    };
+  }
+
+  // Step 4: Validate XML
+  const validation = validateXml(xml);
+  if (!validation.valid) {
+    return {
+      present: false,
+      source: 'unavailable',
+      error: validation.error,
+    };
+  }
+
+  // Step 5: Write to disk
+  const deviceDir = join(mountPoint, DEVICE_DIR);
+  fs.mkdirSync(deviceDir, { recursive: true });
+  fs.writeFileSync(join(mountPoint, SYSINFO_EXTENDED_PATH), xml, 'utf-8');
+
+  // Step 6: Extract device info and return
+  const deviceInfo = extractDeviceInfo(xml);
+  return {
+    present: true,
+    source: 'usb-read',
+    deviceInfo,
+  };
+}

--- a/packages/podkit-core/src/device/sysinfo-extended.ts
+++ b/packages/podkit-core/src/device/sysinfo-extended.ts
@@ -117,14 +117,13 @@ function validateXml(xml: string): { valid: boolean; error?: string } {
 // ── Default USB reader ──────────────────────────────────────────────────────
 
 /**
- * Create the default USB reader function.
+ * Dynamically import the USB reader function from libgpod-node.
  * Returns null if native bindings are not available.
+ * Uses dynamic import() to avoid hard dependency on native bindings.
  */
-function getDefaultUsbReader(): ReadFromUsbFn | null {
+async function getDefaultUsbReader(): Promise<ReadFromUsbFn | null> {
   try {
-    // Dynamic import to avoid hard dependency on native bindings
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const libgpod = require('@podkit/libgpod-node');
+    const libgpod = await import('@podkit/libgpod-node');
     if (typeof libgpod.isNativeAvailable === 'function' && !libgpod.isNativeAvailable()) {
       return null;
     }
@@ -189,7 +188,7 @@ export async function ensureSysInfoExtended(
   }
 
   // Step 2: Resolve USB reader
-  const reader = readFromUsb ?? getDefaultUsbReader();
+  const reader = readFromUsb ?? (await getDefaultUsbReader());
   if (!reader) {
     return {
       present: false,

--- a/packages/podkit-core/src/device/usb-discovery.test.ts
+++ b/packages/podkit-core/src/device/usb-discovery.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {
   parseSystemProfilerUsbData,
   parseSysfsUsbDevices,
+  parseLocationId,
   discoverUsbIpods,
+  resolveUsbDeviceFromPath,
+  findBlockDeviceForMount,
+  findUsbAncestor,
 } from './usb-discovery.js';
 import { createUsbOnlyReadinessResult } from './readiness.js';
 
@@ -280,6 +287,56 @@ describe('parseSystemProfilerUsbData', () => {
     expect(result[0]!.modelName).toBe('iPod 5th generation (Video)');
   });
 
+  it('extracts serial number, bus number, and device address', () => {
+    const data = {
+      SPUSBDataType: [
+        {
+          _name: 'USB 3.0 Bus',
+          _items: [
+            {
+              _name: 'iPod',
+              vendor_id: 'apple_vendor_id',
+              product_id: '0x1209',
+              serial_num: '000A27001BC8EED6',
+              location_id: '0x03100000 / 14',
+              Media: [{ bsd_name: 'disk5s2' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = parseSystemProfilerUsbData(data);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.serialNumber).toBe('000A27001BC8EED6');
+    expect(result[0]!.busNumber).toBe(3);
+    expect(result[0]!.deviceAddress).toBe(14);
+    expect(result[0]!.diskIdentifier).toBe('disk5s2');
+  });
+
+  it('omits serial/bus/address fields when not present in system_profiler data', () => {
+    const data = {
+      SPUSBDataType: [
+        {
+          _name: 'USB 3.0 Bus',
+          _items: [
+            {
+              _name: 'iPod',
+              vendor_id: 'apple_vendor_id',
+              product_id: '0x1209',
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = parseSystemProfilerUsbData(data);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.serialNumber).toBeUndefined();
+    expect(result[0]!.busNumber).toBeUndefined();
+    expect(result[0]!.deviceAddress).toBeUndefined();
+  });
+
   it('handles vendor_id in "0x05ac (Apple Inc.)" format', () => {
     const data = {
       SPUSBDataType: [
@@ -299,6 +356,42 @@ describe('parseSystemProfilerUsbData', () => {
     const result = parseSystemProfilerUsbData(data);
     expect(result).toHaveLength(1);
     expect(result[0]!.vendorId).toBe('0x05ac');
+  });
+});
+
+// ── parseLocationId ─────────────────────────────────────────────────────────
+
+describe('parseLocationId', () => {
+  it('parses standard format "0x03100000 / 14"', () => {
+    expect(parseLocationId('0x03100000 / 14')).toEqual({ busNumber: 3, deviceAddress: 14 });
+  });
+
+  it('parses bus 1 with device address 1', () => {
+    expect(parseLocationId('0x01100000 / 1')).toEqual({ busNumber: 1, deviceAddress: 1 });
+  });
+
+  it('parses high bus number', () => {
+    expect(parseLocationId('0xff100000 / 42')).toEqual({ busNumber: 255, deviceAddress: 42 });
+  });
+
+  it('parses hex-only format without device address', () => {
+    expect(parseLocationId('0x03100000')).toEqual({ busNumber: 3 });
+  });
+
+  it('returns empty for undefined input', () => {
+    expect(parseLocationId(undefined)).toEqual({});
+  });
+
+  it('returns empty for empty string', () => {
+    expect(parseLocationId('')).toEqual({});
+  });
+
+  it('returns empty for malformed input', () => {
+    expect(parseLocationId('not-a-location-id')).toEqual({});
+  });
+
+  it('handles no spaces around slash', () => {
+    expect(parseLocationId('0x02100000/7')).toEqual({ busNumber: 2, deviceAddress: 7 });
   });
 });
 
@@ -360,6 +453,33 @@ describe('parseSysfsUsbDevices', () => {
     const result = parseSysfsUsbDevices(devices);
     expect(result[0]!.diskIdentifier).toBeUndefined();
   });
+
+  it('extracts busnum, devnum, and serial from sysfs', () => {
+    const devices = [
+      {
+        idVendor: '05ac',
+        idProduct: '1209',
+        busnum: '3',
+        devnum: '14',
+        serial: '000A27001BC8EED6',
+      },
+    ];
+
+    const result = parseSysfsUsbDevices(devices);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.busNumber).toBe(3);
+    expect(result[0]!.deviceAddress).toBe(14);
+    expect(result[0]!.serialNumber).toBe('000A27001BC8EED6');
+  });
+
+  it('omits bus/address/serial when not present in sysfs', () => {
+    const devices = [{ idVendor: '05ac', idProduct: '1209' }];
+
+    const result = parseSysfsUsbDevices(devices);
+    expect(result[0]!.busNumber).toBeUndefined();
+    expect(result[0]!.deviceAddress).toBeUndefined();
+    expect(result[0]!.serialNumber).toBeUndefined();
+  });
 });
 
 // ── discoverUsbIpods ─────────────────────────────────────────────────────────
@@ -373,6 +493,132 @@ describe('discoverUsbIpods', () => {
   it('returns empty array for unknown platform', async () => {
     const result = await discoverUsbIpods({ platform: 'freebsd' });
     expect(result).toEqual([]);
+  });
+});
+
+// ── resolveUsbDeviceFromPath ─────────────────────────────────────────────────
+
+describe('resolveUsbDeviceFromPath', () => {
+  it('returns null for unsupported platform', async () => {
+    const result = await resolveUsbDeviceFromPath('/mnt/ipod', { platform: 'win32' });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for unknown platform', async () => {
+    const result = await resolveUsbDeviceFromPath('/mnt/ipod', { platform: 'freebsd' });
+    expect(result).toBeNull();
+  });
+});
+
+// ── findBlockDeviceForMount ──────────────────────────────────────────────────
+
+describe('findBlockDeviceForMount', () => {
+  const PROC_MOUNTS = [
+    '/dev/sda1 /mnt/ipod ext4 rw,relatime 0 0',
+    '/dev/sdb1 /mnt/usb vfat rw,relatime 0 0',
+    'tmpfs /tmp tmpfs rw 0 0',
+    'proc /proc proc rw 0 0',
+  ].join('\n');
+
+  it('finds block device for matching mount path', () => {
+    expect(findBlockDeviceForMount('/mnt/ipod', PROC_MOUNTS)).toBe('sda1');
+  });
+
+  it('finds second device', () => {
+    expect(findBlockDeviceForMount('/mnt/usb', PROC_MOUNTS)).toBe('sdb1');
+  });
+
+  it('returns null for unmatched mount path', () => {
+    expect(findBlockDeviceForMount('/mnt/other', PROC_MOUNTS)).toBeNull();
+  });
+
+  it('ignores non-device mounts (tmpfs, proc)', () => {
+    expect(findBlockDeviceForMount('/tmp', PROC_MOUNTS)).toBeNull();
+    expect(findBlockDeviceForMount('/proc', PROC_MOUNTS)).toBeNull();
+  });
+
+  it('handles trailing slash on mount path', () => {
+    expect(findBlockDeviceForMount('/mnt/ipod/', PROC_MOUNTS)).toBe('sda1');
+  });
+
+  it('returns null for empty content', () => {
+    expect(findBlockDeviceForMount('/mnt/ipod', '')).toBeNull();
+  });
+});
+
+// ── findUsbAncestor ─────────────────────────────────────────────────────────
+
+describe('findUsbAncestor', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'usb-ancestor-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('finds USB ancestor with busnum and devnum', () => {
+    // Simulate sysfs: /sys/devices/pci.../usb1/1-1/1-1:1.0/host0/target0/0:0:0:0/block/sda
+    // The USB device is at 1-1 level where busnum + devnum live
+    const usbDevice = path.join(tmpDir, 'usb1', '1-1');
+    const blockDevice = path.join(usbDevice, '1-1:1.0', 'host0', 'target0', '0:0:0:0');
+
+    fs.mkdirSync(blockDevice, { recursive: true });
+    fs.writeFileSync(path.join(usbDevice, 'busnum'), '1\n');
+    fs.writeFileSync(path.join(usbDevice, 'devnum'), '14\n');
+
+    // The "sysBlockDevicePath" is what /sys/block/sda/device resolves to
+    const result = findUsbAncestor(blockDevice, {
+      realpathSync: (p: string) => p, // already resolved in test
+      existsSync: (p: string) => fs.existsSync(p),
+    });
+
+    expect(result).toBe(usbDevice);
+  });
+
+  it('returns null when no USB ancestor exists', () => {
+    const noUsbPath = path.join(tmpDir, 'some', 'deep', 'path');
+    fs.mkdirSync(noUsbPath, { recursive: true });
+
+    const result = findUsbAncestor(noUsbPath, {
+      realpathSync: (p: string) => p,
+      existsSync: (p: string) => fs.existsSync(p),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when realpath fails (broken symlink)', () => {
+    const result = findUsbAncestor('/sys/block/nonexistent/device', {
+      realpathSync: () => {
+        throw new Error('ENOENT');
+      },
+      existsSync: () => false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('finds nearest USB ancestor (not a higher one)', () => {
+    // Two levels with busnum/devnum — should find the deepest (nearest to device)
+    const outerUsb = path.join(tmpDir, 'usb1');
+    const innerUsb = path.join(outerUsb, '1-1');
+    const device = path.join(innerUsb, '1-1:1.0', 'host0');
+
+    fs.mkdirSync(device, { recursive: true });
+    fs.writeFileSync(path.join(outerUsb, 'busnum'), '1\n');
+    fs.writeFileSync(path.join(outerUsb, 'devnum'), '1\n');
+    fs.writeFileSync(path.join(innerUsb, 'busnum'), '1\n');
+    fs.writeFileSync(path.join(innerUsb, 'devnum'), '14\n');
+
+    const result = findUsbAncestor(device, {
+      realpathSync: (p: string) => p,
+      existsSync: (p: string) => fs.existsSync(p),
+    });
+
+    expect(result).toBe(innerUsb);
   });
 });
 

--- a/packages/podkit-core/src/device/usb-discovery.ts
+++ b/packages/podkit-core/src/device/usb-discovery.ts
@@ -31,6 +31,12 @@ export interface UsbDiscoveredDevice {
   supported: boolean;
   /** Human-readable not-supported message for unsupported models */
   notSupportedReason?: string;
+  /** USB serial number (= FirewireGuid for iPods, 16 hex chars) */
+  serialNumber?: string;
+  /** USB bus number (for libusb device addressing) */
+  busNumber?: number;
+  /** USB device address (for libusb device addressing) */
+  deviceAddress?: number;
 }
 
 // ── Unsupported device definitions ───────────────────────────────────────────
@@ -41,6 +47,7 @@ const UNSUPPORTED_IPODS: Record<string, string> = {
   '0x1303':
     'iPod Shuffle 3rd/4th generation requires iTunes authentication and cannot be used with podkit.',
   '0x120d': 'iPod Nano 6th generation uses a different database format not supported by libgpod.',
+  '0x1266': 'iPod Nano 6th generation uses a different database format not supported by libgpod.',
 };
 
 /** Product ID ranges for iPod Touch / iOS devices */
@@ -74,6 +81,8 @@ interface SystemProfilerItem {
   _name?: string;
   vendor_id?: string;
   product_id?: string;
+  serial_num?: string;
+  location_id?: string;
   _items?: SystemProfilerItem[];
   Media?: Array<{ bsd_name?: string; [key: string]: unknown }>;
   [key: string]: unknown;
@@ -107,6 +116,8 @@ export function parseSystemProfilerUsbData(data: unknown): UsbDiscoveredDevice[]
             // It's a known iPod — check if supported
             const unsupportedReason = getUnsupportedReason(productId);
             const diskIdentifier = extractBsdName(item);
+            const serialNumber = extractSerialNumber(item);
+            const { busNumber, deviceAddress } = parseLocationId(item.location_id);
 
             results.push({
               vendorId: APPLE_VENDOR_ID,
@@ -115,6 +126,9 @@ export function parseSystemProfilerUsbData(data: unknown): UsbDiscoveredDevice[]
               ...(diskIdentifier ? { diskIdentifier } : {}),
               supported: !unsupportedReason,
               ...(unsupportedReason ? { notSupportedReason: unsupportedReason } : {}),
+              ...(serialNumber ? { serialNumber } : {}),
+              ...(busNumber !== undefined ? { busNumber } : {}),
+              ...(deviceAddress !== undefined ? { deviceAddress } : {}),
             });
           }
           // Non-iPod Apple devices (iPhones, iPads, AirPods) are silently ignored
@@ -156,6 +170,47 @@ function extractBsdName(item: SystemProfilerItem): string | undefined {
   return undefined;
 }
 
+/** Extract serial_num from a system_profiler item (16 hex chars for iPods) */
+function extractSerialNumber(item: SystemProfilerItem): string | undefined {
+  if (typeof item.serial_num === 'string' && item.serial_num.length > 0) {
+    return item.serial_num;
+  }
+  return undefined;
+}
+
+/**
+ * Parse location_id from system_profiler into bus number and device address.
+ * Format: "0x03100000 / 14" → { busNumber: 3, deviceAddress: 14 }
+ * The top byte of the hex value is the bus number; the number after " / " is the device address.
+ */
+export function parseLocationId(locationId: string | undefined): {
+  busNumber?: number;
+  deviceAddress?: number;
+} {
+  if (!locationId || typeof locationId !== 'string') return {};
+
+  const match = locationId.match(/^0x([\da-fA-F]+)\s*\/\s*(\d+)$/);
+  if (!match) {
+    // Try format without device address: "0x03100000"
+    const hexOnly = locationId.match(/^0x([\da-fA-F]+)$/);
+    if (hexOnly) {
+      const hexValue = parseInt(hexOnly[1]!, 16);
+      const busNumber = (hexValue >> 24) & 0xff;
+      return busNumber > 0 ? { busNumber } : {};
+    }
+    return {};
+  }
+
+  const hexValue = parseInt(match[1]!, 16);
+  const busNumber = (hexValue >> 24) & 0xff;
+  const deviceAddress = parseInt(match[2]!, 10);
+
+  return {
+    ...(busNumber > 0 ? { busNumber } : {}),
+    ...(Number.isFinite(deviceAddress) ? { deviceAddress } : {}),
+  };
+}
+
 async function discoverMacOS(): Promise<UsbDiscoveredDevice[]> {
   try {
     const stdout = await new Promise<string>((resolve, reject) => {
@@ -180,9 +235,12 @@ async function discoverMacOS(): Promise<UsbDiscoveredDevice[]> {
 
 // ── Linux implementation ─────────────────────────────────────────────────────
 
-interface SysfsUsbDevice {
+export interface SysfsUsbDevice {
   idVendor: string;
   idProduct: string;
+  busnum?: string;
+  devnum?: string;
+  serial?: string;
 }
 
 /**
@@ -201,6 +259,9 @@ export function parseSysfsUsbDevices(deviceDirs: SysfsUsbDevice[]): UsbDiscovere
     if (!modelName) continue;
 
     const unsupportedReason = getUnsupportedReason(productId);
+    const busNumber = device.busnum ? parseInt(device.busnum, 10) : undefined;
+    const deviceAddress = device.devnum ? parseInt(device.devnum, 10) : undefined;
+    const serialNumber = device.serial && device.serial.length > 0 ? device.serial : undefined;
 
     results.push({
       vendorId: APPLE_VENDOR_ID,
@@ -209,6 +270,9 @@ export function parseSysfsUsbDevices(deviceDirs: SysfsUsbDevice[]): UsbDiscovere
       // No disk identifier available from sysfs easily
       supported: !unsupportedReason,
       ...(unsupportedReason ? { notSupportedReason: unsupportedReason } : {}),
+      ...(serialNumber ? { serialNumber } : {}),
+      ...(Number.isFinite(busNumber) ? { busNumber } : {}),
+      ...(Number.isFinite(deviceAddress) ? { deviceAddress } : {}),
     });
   }
 
@@ -230,7 +294,28 @@ async function discoverLinux(): Promise<UsbDiscoveredDevice[]> {
       try {
         const idVendor = fs.readFileSync(vendorPath, 'utf-8').trim();
         const idProduct = fs.readFileSync(productPath, 'utf-8').trim();
-        devices.push({ idVendor, idProduct });
+
+        // Read optional sysfs fields for bus/device/serial
+        let busnum: string | undefined;
+        let devnum: string | undefined;
+        let serial: string | undefined;
+        try {
+          busnum = fs.readFileSync(path.join(deviceDir, 'busnum'), 'utf-8').trim();
+        } catch {
+          /* not always present */
+        }
+        try {
+          devnum = fs.readFileSync(path.join(deviceDir, 'devnum'), 'utf-8').trim();
+        } catch {
+          /* not always present */
+        }
+        try {
+          serial = fs.readFileSync(path.join(deviceDir, 'serial'), 'utf-8').trim();
+        } catch {
+          /* not always present */
+        }
+
+        devices.push({ idVendor, idProduct, busnum, devnum, serial });
       } catch {
         // Not all entries have idVendor/idProduct (e.g., hub ports) — skip
         continue;
@@ -242,6 +327,226 @@ async function discoverLinux(): Promise<UsbDiscoveredDevice[]> {
     // /sys/bus/usb/devices doesn't exist or permission denied — graceful degradation
     return [];
   }
+}
+
+// ── Path-to-USB correlation ─────────────────────────────────────────────────
+
+/**
+ * Resolve USB device info (bus number, device address, serial) from a mount path.
+ *
+ * macOS: Runs diskutil + system_profiler to correlate mount path → bsd_name → USB device.
+ * Linux: Parses /proc/mounts → sysfs block device → walks up to USB ancestor for bus/address/serial.
+ *
+ * Never throws — returns null on any failure.
+ */
+export async function resolveUsbDeviceFromPath(
+  mountPath: string,
+  options?: { platform?: string }
+): Promise<Pick<UsbDiscoveredDevice, 'busNumber' | 'deviceAddress' | 'serialNumber'> | null> {
+  const platform = options?.platform ?? process.platform;
+
+  try {
+    switch (platform) {
+      case 'darwin':
+        return await resolveUsbDeviceFromPathMacOS(mountPath);
+      case 'linux':
+        return await resolveUsbDeviceFromPathLinux(mountPath);
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the block device for a mount path by parsing /proc/mounts.
+ * Exported for testing.
+ *
+ * @returns Block device basename (e.g., "sda1") or null
+ */
+export function findBlockDeviceForMount(
+  mountPath: string,
+  procMountsContent: string
+): string | null {
+  // Normalise trailing slash for comparison
+  const normalised =
+    mountPath.endsWith('/') && mountPath !== '/' ? mountPath.slice(0, -1) : mountPath;
+
+  for (const line of procMountsContent.split('\n')) {
+    const parts = line.split(' ');
+    if (parts.length < 2) continue;
+    const device = parts[0]!;
+    const mount = parts[1]!;
+    if (mount === normalised && device.startsWith('/dev/')) {
+      return path.basename(device);
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk from a sysfs block device path up to the USB device ancestor.
+ * Exported for testing.
+ *
+ * Starting from /sys/block/{dev}/device, follows the symlink and walks
+ * parent directories until finding one that contains busnum+devnum files
+ * (indicating a USB device node).
+ *
+ * @returns Absolute path to the USB device sysfs directory, or null
+ */
+export function findUsbAncestor(
+  sysBlockDevicePath: string,
+  fsAccess: {
+    realpathSync: (p: string) => string;
+    existsSync: (p: string) => boolean;
+  } = fs
+): string | null {
+  let devicePath: string;
+  try {
+    devicePath = fsAccess.realpathSync(sysBlockDevicePath);
+  } catch {
+    return null;
+  }
+
+  // Walk up from the resolved device path looking for busnum + devnum
+  let current = devicePath;
+  const root = '/sys';
+  while (current.length > root.length) {
+    const busnumPath = path.join(current, 'busnum');
+    const devnumPath = path.join(current, 'devnum');
+    if (fsAccess.existsSync(busnumPath) && fsAccess.existsSync(devnumPath)) {
+      return current;
+    }
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+async function resolveUsbDeviceFromPathLinux(
+  mountPath: string
+): Promise<Pick<UsbDiscoveredDevice, 'busNumber' | 'deviceAddress' | 'serialNumber'> | null> {
+  // Step 1: Find block device from /proc/mounts
+  let procMounts: string;
+  try {
+    procMounts = fs.readFileSync('/proc/mounts', 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const blockDev = findBlockDeviceForMount(mountPath, procMounts);
+  if (!blockDev) return null;
+
+  // Strip partition suffix (sda1 → sda) for sysfs lookup
+  const baseDev = blockDev.replace(/\d+$/, '');
+
+  // Step 2: Follow /sys/block/{dev}/device symlink up to USB device
+  const sysBlockDevice = `/sys/block/${baseDev}/device`;
+  const usbDevicePath = findUsbAncestor(sysBlockDevice);
+  if (!usbDevicePath) return null;
+
+  // Step 3: Read USB device attributes
+  const result: Pick<UsbDiscoveredDevice, 'busNumber' | 'deviceAddress' | 'serialNumber'> = {};
+
+  try {
+    const busnum = parseInt(
+      fs.readFileSync(path.join(usbDevicePath, 'busnum'), 'utf-8').trim(),
+      10
+    );
+    if (Number.isFinite(busnum)) result.busNumber = busnum;
+  } catch {
+    /* not available */
+  }
+
+  try {
+    const devnum = parseInt(
+      fs.readFileSync(path.join(usbDevicePath, 'devnum'), 'utf-8').trim(),
+      10
+    );
+    if (Number.isFinite(devnum)) result.deviceAddress = devnum;
+  } catch {
+    /* not available */
+  }
+
+  try {
+    const serial = fs.readFileSync(path.join(usbDevicePath, 'serial'), 'utf-8').trim();
+    if (serial.length > 0) result.serialNumber = serial;
+  } catch {
+    /* not available */
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+async function resolveUsbDeviceFromPathMacOS(
+  mountPath: string
+): Promise<Pick<UsbDiscoveredDevice, 'busNumber' | 'deviceAddress' | 'serialNumber'> | null> {
+  // Step 1: Get BSD name from diskutil info
+  const diskutilOutput = await new Promise<string>((resolve, reject) => {
+    execFile('diskutil', ['info', mountPath], { timeout: 10_000 }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+
+  // Extract "Device Node: /dev/disk5s2" → "disk5s2", then strip partition suffix → "disk5"
+  const deviceNodeMatch = diskutilOutput.match(/Device Node:\s*\/dev\/(disk\d+)/);
+  if (!deviceNodeMatch) return null;
+  const bsdNamePrefix = deviceNodeMatch[1]!;
+
+  // Step 2: Get system_profiler USB data
+  const spOutput = await new Promise<string>((resolve, reject) => {
+    execFile(
+      'system_profiler',
+      ['SPUSBDataType', '-json'],
+      { timeout: 10_000 },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      }
+    );
+  });
+
+  const spData = JSON.parse(spOutput) as SystemProfilerData;
+  if (!spData.SPUSBDataType) return null;
+
+  // Step 3: Walk USB tree to find device with matching bsd_name
+  function findDeviceByBsdName(items: SystemProfilerItem[]): SystemProfilerItem | undefined {
+    for (const item of items) {
+      if (Array.isArray(item.Media)) {
+        for (const media of item.Media) {
+          if (typeof media.bsd_name === 'string' && media.bsd_name === bsdNamePrefix) {
+            return item;
+          }
+        }
+      }
+      if (Array.isArray(item._items)) {
+        const found = findDeviceByBsdName(item._items);
+        if (found) return found;
+      }
+    }
+    return undefined;
+  }
+
+  let matchedItem: SystemProfilerItem | undefined;
+  for (const bus of spData.SPUSBDataType) {
+    if (Array.isArray(bus._items)) {
+      matchedItem = findDeviceByBsdName(bus._items);
+      if (matchedItem) break;
+    }
+  }
+
+  if (!matchedItem) return null;
+
+  const serialNumber = extractSerialNumber(matchedItem);
+  const { busNumber, deviceAddress } = parseLocationId(matchedItem.location_id);
+
+  const result: Pick<UsbDiscoveredDevice, 'busNumber' | 'deviceAddress' | 'serialNumber'> = {};
+  if (serialNumber) result.serialNumber = serialNumber;
+  if (busNumber !== undefined) result.busNumber = busNumber;
+  if (deviceAddress !== undefined) result.deviceAddress = deviceAddress;
+
+  return Object.keys(result).length > 0 ? result : null;
 }
 
 // ── Main entry point ─────────────────────────────────────────────────────────

--- a/packages/podkit-core/src/diagnostics/checks/sysinfo-extended.ts
+++ b/packages/podkit-core/src/diagnostics/checks/sysinfo-extended.ts
@@ -1,0 +1,128 @@
+/**
+ * SysInfoExtended diagnostic check
+ *
+ * Checks whether SysInfoExtended is present on the device and provides
+ * a repair action that reads device identity from iPod firmware via USB
+ * and writes it to the filesystem.
+ */
+
+import { readSysInfoExtended, ensureSysInfoExtended } from '../../device/sysinfo-extended.js';
+import { resolveUsbDeviceFromPath } from '../../device/usb-discovery.js';
+import type {
+  DiagnosticCheck,
+  CheckResult,
+  DiagnosticContext,
+  RepairContext,
+  RepairRunOptions,
+  RepairResult,
+} from '../types.js';
+
+export const sysInfoExtendedCheck: DiagnosticCheck = {
+  id: 'sysinfo-extended',
+  name: 'SysInfoExtended',
+  applicableTo: ['ipod'],
+
+  async check(ctx: DiagnosticContext): Promise<CheckResult> {
+    const result = readSysInfoExtended(ctx.mountPoint);
+
+    if (result && result.present && result.deviceInfo) {
+      const info = result.deviceInfo;
+      const model = info.modelName ?? 'Unknown iPod';
+      return {
+        status: 'pass',
+        summary: `${model} — SysInfoExtended present`,
+        repairable: false,
+        details: {
+          firewireGuid: info.firewireGuid,
+          serialNumber: info.serialNumber,
+          modelName: info.modelName,
+          generationId: info.generationId,
+          checksumType: info.checksumType,
+        },
+      };
+    }
+
+    return {
+      status: 'warn',
+      summary:
+        'SysInfoExtended not found — run `podkit doctor --repair sysinfo-extended` to read from USB',
+      repairable: true,
+    };
+  },
+
+  repair: {
+    description: 'Read device identity from iPod firmware via USB',
+    requirements: ['writable-device'],
+
+    async run(ctx: RepairContext, options?: RepairRunOptions): Promise<RepairResult> {
+      // Step 1: Resolve USB device from mount path
+      options?.onProgress?.({
+        phase: 'resolving',
+        message: 'Resolving USB device from mount path',
+      });
+
+      const usbDevice = await resolveUsbDeviceFromPath(ctx.mountPoint);
+      if (
+        !usbDevice ||
+        usbDevice.busNumber === undefined ||
+        usbDevice.deviceAddress === undefined
+      ) {
+        return {
+          success: false,
+          summary: 'Could not find USB device for this iPod',
+          details: {
+            mountPoint: ctx.mountPoint,
+            error: 'USB device resolution failed — ensure the iPod is connected via USB',
+          },
+        };
+      }
+
+      if (options?.dryRun) {
+        return {
+          success: true,
+          summary: `Dry run: would read SysInfoExtended from USB bus ${usbDevice.busNumber} device ${usbDevice.deviceAddress}`,
+          details: {
+            busNumber: usbDevice.busNumber,
+            deviceAddress: usbDevice.deviceAddress,
+          },
+        };
+      }
+
+      // Step 2: Read from USB and write to device
+      options?.onProgress?.({
+        phase: 'reading',
+        message: `Reading SysInfoExtended from USB bus ${usbDevice.busNumber} device ${usbDevice.deviceAddress}`,
+      });
+
+      const result = await ensureSysInfoExtended(ctx.mountPoint, {
+        busNumber: usbDevice.busNumber,
+        deviceAddress: usbDevice.deviceAddress,
+      });
+
+      if (!result.present) {
+        return {
+          success: false,
+          summary: result.error ?? 'Failed to read SysInfoExtended from USB',
+          details: {
+            source: result.source,
+            error: result.error,
+          },
+        };
+      }
+
+      const model = result.deviceInfo?.modelName ?? 'Unknown iPod';
+      return {
+        success: true,
+        summary: `SysInfoExtended ${result.source === 'existing' ? 'already present' : 'written'} — ${model}`,
+        details: {
+          source: result.source,
+          firewireGuid: result.deviceInfo?.firewireGuid,
+          serialNumber: result.deviceInfo?.serialNumber,
+          modelName: result.deviceInfo?.modelName,
+          generationId: result.deviceInfo?.generationId,
+          checksumType: result.deviceInfo?.checksumType,
+        },
+      };
+    },
+  },
+};

--- a/packages/podkit-core/src/diagnostics/checks/sysinfo-extended.ts
+++ b/packages/podkit-core/src/diagnostics/checks/sysinfo-extended.ts
@@ -1,12 +1,13 @@
 /**
- * SysInfoExtended diagnostic check
+ * SysInfoExtended repair-only check.
  *
- * Checks whether SysInfoExtended is present on the device and provides
- * a repair action that reads device identity from iPod firmware via USB
- * and writes it to the filesystem.
+ * Detection lives in the readiness `sysinfo` stage (single source of truth
+ * for device identity). This check exposes the repair action that reads
+ * device identity from iPod firmware via USB and writes it to the filesystem,
+ * accessible via `podkit doctor --repair sysinfo-extended`.
  */
 
-import { readSysInfoExtended, ensureSysInfoExtended } from '../../device/sysinfo-extended.js';
+import { ensureSysInfoExtended } from '../../device/sysinfo-extended.js';
 import { resolveUsbDeviceFromPath } from '../../device/usb-discovery.js';
 import type {
   DiagnosticCheck,
@@ -21,32 +22,13 @@ export const sysInfoExtendedCheck: DiagnosticCheck = {
   id: 'sysinfo-extended',
   name: 'SysInfoExtended',
   applicableTo: ['ipod'],
+  repairOnly: true,
 
-  async check(ctx: DiagnosticContext): Promise<CheckResult> {
-    const result = readSysInfoExtended(ctx.mountPoint);
-
-    if (result && result.present && result.deviceInfo) {
-      const info = result.deviceInfo;
-      const model = info.modelName ?? 'Unknown iPod';
-      return {
-        status: 'pass',
-        summary: `${model} — SysInfoExtended present`,
-        repairable: false,
-        details: {
-          firewireGuid: info.firewireGuid,
-          serialNumber: info.serialNumber,
-          modelName: info.modelName,
-          generationId: info.generationId,
-          checksumType: info.checksumType,
-        },
-      };
-    }
-
+  async check(_ctx: DiagnosticContext): Promise<CheckResult> {
     return {
-      status: 'warn',
-      summary:
-        'SysInfoExtended not found — run `podkit doctor --repair sysinfo-extended` to read from USB',
-      repairable: true,
+      status: 'skip',
+      summary: 'SysInfoExtended is a repair-only action (run with --repair sysinfo-extended)',
+      repairable: false,
     };
   },
 

--- a/packages/podkit-core/src/diagnostics/index.ts
+++ b/packages/podkit-core/src/diagnostics/index.ts
@@ -18,6 +18,7 @@ import { artworkResetCheck } from './checks/artwork-reset.js';
 import { codecEncodersCheck } from './checks/codec-encoders.js';
 import { orphanFilesCheck } from './checks/orphans.js';
 import { orphanFilesMassStorageCheck } from './checks/orphans-mass-storage.js';
+import { sysInfoExtendedCheck } from './checks/sysinfo-extended.js';
 import type {
   DiagnosticCheck,
   DiagnosticReport,
@@ -48,6 +49,7 @@ const CHECKS: DiagnosticCheck[] = [
   codecEncodersCheck,
   orphanFilesCheck,
   orphanFilesMassStorageCheck,
+  sysInfoExtendedCheck,
 ];
 
 /**

--- a/packages/podkit-core/src/index.ts
+++ b/packages/podkit-core/src/index.ts
@@ -583,7 +583,11 @@ export {
 
 // USB discovery
 export type { UsbDiscoveredDevice } from './device/index.js';
-export { discoverUsbIpods } from './device/index.js';
+export { discoverUsbIpods, resolveUsbDeviceFromPath } from './device/index.js';
+
+// SysInfoExtended (device identity from USB firmware)
+export type { SysInfoExtendedResult } from './device/index.js';
+export { readSysInfoExtended, ensureSysInfoExtended } from './device/index.js';
 
 // OS error code interpreter
 export type { InterpretedError } from './device/index.js';

--- a/packages/podkit-core/src/index.ts
+++ b/packages/podkit-core/src/index.ts
@@ -589,6 +589,9 @@ export { discoverUsbIpods, resolveUsbDeviceFromPath } from './device/index.js';
 export type { SysInfoExtendedResult } from './device/index.js';
 export { readSysInfoExtended, ensureSysInfoExtended } from './device/index.js';
 
+// iPod model lookup
+export { getChecksumTypeByModelNumber } from './device/index.js';
+
 // OS error code interpreter
 export type { InterpretedError } from './device/index.js';
 export { interpretError } from './device/index.js';

--- a/tools/gpod-tool/Makefile
+++ b/tools/gpod-tool/Makefile
@@ -17,13 +17,15 @@ PREFIX ?= /usr/local
 
 # Get flags from pkg-config
 PKG_CONFIG ?= pkg-config
-LIBGPOD_CFLAGS := $(shell $(PKG_CONFIG) --cflags libgpod-1.0 2>/dev/null)
-LIBGPOD_LIBS := $(shell $(PKG_CONFIG) --libs libgpod-1.0 2>/dev/null)
+LIBGPOD_CFLAGS := $(shell $(PKG_CONFIG) --cflags libgpod-1.0 glib-2.0 2>/dev/null)
+LIBGPOD_LIBS := $(shell $(PKG_CONFIG) --libs libgpod-1.0 glib-2.0 2>/dev/null)
 
-# Path to libgpod source for private headers (itdb_thumb.h, itdb_device.h)
-# Required for artwork-dump command which accesses internal thumb structures
+# Path to libgpod source for private headers (itdb_thumb.h)
+# Optional: enables artwork-dump command which accesses internal thumb structures.
+# On macOS with local build, these are found automatically. On Linux with system
+# libgpod-dev, private headers are not installed so artwork-dump is disabled.
 LIBGPOD_SRC_DIR ?= $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../../tools/libgpod-macos/build/libgpod-0.8.3/src)
-LIBGPOD_PRIVATE_CFLAGS := $(if $(wildcard $(LIBGPOD_SRC_DIR)/itdb_thumb.h),-I$(LIBGPOD_SRC_DIR),)
+LIBGPOD_PRIVATE_CFLAGS := $(if $(wildcard $(LIBGPOD_SRC_DIR)/itdb_thumb.h),-I$(LIBGPOD_SRC_DIR) -DHAVE_LIBGPOD_PRIVATE,)
 
 # Check if libgpod was found
 ifeq ($(LIBGPOD_CFLAGS),)

--- a/tools/gpod-tool/gpod-tool.c
+++ b/tools/gpod-tool/gpod-tool.c
@@ -23,7 +23,9 @@
 #include <getopt.h>
 #include <gpod/itdb.h>
 #include <glib.h>
+#ifdef HAVE_LIBGPOD_PRIVATE
 #include "itdb_thumb.h"
+#endif
 
 #define VERSION "0.1.0"
 
@@ -807,9 +809,10 @@ static int cmd_verify(int argc, char *argv[]) {
 }
 
 /* ============================================================================
- * Command: artwork-dump
+ * Command: artwork-dump (requires private libgpod headers)
  * ============================================================================ */
 
+#ifdef HAVE_LIBGPOD_PRIVATE
 static void print_artwork_dump_usage(void) {
     fprintf(stderr, "Usage: gpod-tool artwork-dump <path> [options]\n");
     fprintf(stderr, "\n");
@@ -1006,6 +1009,7 @@ static int cmd_artwork_dump(int argc, char *argv[]) {
     itdb_free(itdb);
     return 0;
 }
+#endif /* HAVE_LIBGPOD_PRIVATE */
 
 /* ============================================================================
  * Main
@@ -1022,7 +1026,9 @@ static void print_usage(void) {
     fprintf(stderr, "  tracks        List all tracks\n");
     fprintf(stderr, "  add-track     Add a track entry (metadata only)\n");
     fprintf(stderr, "  verify        Verify database can be parsed\n");
+#ifdef HAVE_LIBGPOD_PRIVATE
     fprintf(stderr, "  artwork-dump  Dump artwork information from the database\n");
+#endif
     fprintf(stderr, "\n");
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "  -j, --json  Output as JSON (all commands)\n");
@@ -1033,7 +1039,9 @@ static void print_usage(void) {
     fprintf(stderr, "  gpod-tool info ./test-ipod --json\n");
     fprintf(stderr, "  gpod-tool add-track ./test-ipod -t \"Song\" -a \"Artist\"\n");
     fprintf(stderr, "  gpod-tool verify ./test-ipod\n");
+#ifdef HAVE_LIBGPOD_PRIVATE
     fprintf(stderr, "  gpod-tool artwork-dump /Volumes/iPod --json\n");
+#endif
 }
 
 int main(int argc, char *argv[]) {
@@ -1071,8 +1079,10 @@ int main(int argc, char *argv[]) {
         return cmd_add_track(argc, argv);
     } else if (strcmp(command, "verify") == 0) {
         return cmd_verify(argc, argv);
+#ifdef HAVE_LIBGPOD_PRIVATE
     } else if (strcmp(command, "artwork-dump") == 0) {
         return cmd_artwork_dump(argc, argv);
+#endif
     } else {
         fprintf(stderr, "Unknown command: %s\n\n", command);
         print_usage();

--- a/tools/lima/run-tests.sh
+++ b/tools/lima/run-tests.sh
@@ -72,10 +72,25 @@ run_tests() {
       --exclude 'packages/libgpod-node/prebuilds' \
       --exclude 'packages/demo/bin' \
       --exclude 'packages/podkit-cli/bin' \
+      --exclude 'bin/' \
+      --exclude 'tools/gpod-tool/gpod-tool' \
+      --exclude 'tools/gpod-tool/*.o' \
       '$REPO_DIR/' '$VM_WORK_DIR/'
 
     cd '$VM_WORK_DIR'
+    rm -rf .turbo
     bun install
+
+    # Build native tools and bindings (needed for integration tests)
+    make -C tools/gpod-tool clean 2>/dev/null || true
+    make -C tools/gpod-tool
+    mkdir -p bin
+    cp tools/gpod-tool/gpod-tool bin/
+    export PATH=\$PWD/bin:\$PATH
+
+    # Build libgpod-node native binding for this platform
+    cd packages/libgpod-node && node-gyp rebuild && cd \$OLDPWD
+
     bun run test --filter @podkit/core
   "
 

--- a/tools/prebuild/build-static-deps.sh
+++ b/tools/prebuild/build-static-deps.sh
@@ -115,6 +115,9 @@ if [ "$OS" = "Darwin" ]; then
     fi
   done
 
+  LIBUSB_PREFIX="$(brew --prefix libusb)"
+  copy_if_exists "$LIBUSB_PREFIX/lib/libusb-1.0.a" "$STATIC_DEPS_DIR/lib/libusb-1.0.a"
+
   # 2. Build gdk-pixbuf .a (Homebrew doesn't ship static lib)
   PKG_PATHS="$HOMEBREW_PREFIX/lib/pkgconfig"
   LINK_ARGS=""
@@ -150,9 +153,12 @@ if [ "$OS" = "Darwin" ]; then
     patch -p0 < callout.patch
     patch -p1 < libplist.patch
 
+    # Add itdb_usb.c for SysInfoExtended USB read support
+    bash "$REPO_ROOT/tools/prebuild/patches/apply-sysinfo-usb.sh"
+
     # Use Homebrew pkg-config paths — same as tools/libgpod-macos/build.sh
     LIBPLIST_PREFIX="$(brew --prefix libplist)"
-    export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig:$LIBPLIST_PREFIX/lib/pkgconfig"
+    export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/lib/pkgconfig:$LIBPLIST_PREFIX/lib/pkgconfig:$LIBUSB_PREFIX/lib/pkgconfig"
     export CFLAGS="-I$HOMEBREW_PREFIX/include -I$LIBPLIST_PREFIX/include"
     export LDFLAGS="-L$HOMEBREW_PREFIX/lib -L$LIBPLIST_PREFIX/lib"
 
@@ -469,6 +475,34 @@ elif [ "$OS" = "Linux" ]; then
     "-L$STATIC_DEPS_DIR/lib -lpng16 -ljpeg -ltiff -lz"
 
   # -----------------------------------------------------------------------
+  # Phase 4.5: libusb (no dependencies beyond libc)
+  # -----------------------------------------------------------------------
+  if [ ! -f "$STATIC_DEPS_DIR/lib/libusb-1.0.a" ]; then
+    log "Building libusb 1.0.27 (static, -fPIC)..."
+    cd "$WORK_DIR"
+
+    LIBUSB_VERSION="1.0.27"
+    if [ ! -f "libusb-${LIBUSB_VERSION}.tar.bz2" ]; then
+      curl -L -o "libusb-${LIBUSB_VERSION}.tar.bz2" \
+        "https://github.com/libusb/libusb/releases/download/v${LIBUSB_VERSION}/libusb-${LIBUSB_VERSION}.tar.bz2"
+    fi
+
+    rm -rf "libusb-${LIBUSB_VERSION}"
+    tar xjf "libusb-${LIBUSB_VERSION}.tar.bz2"
+    cd "libusb-${LIBUSB_VERSION}"
+
+    ./configure \
+      --prefix="$STATIC_DEPS_DIR" \
+      --enable-static --disable-shared \
+      --disable-udev \
+      CFLAGS="-fPIC"
+    make -j"$NPROC"
+    make install
+  else
+    log "libusb already built, skipping"
+  fi
+
+  # -----------------------------------------------------------------------
   # Phase 5: libgpod (needs glib, gdk-pixbuf, libplist, libxml2, sqlite3)
   # -----------------------------------------------------------------------
   if [ ! -f "$STATIC_DEPS_DIR/lib/libgpod.a" ]; then
@@ -490,6 +524,9 @@ elif [ "$OS" = "Linux" ]; then
     curl -sL -o libplist.patch "https://raw.githubusercontent.com/pld-linux/libgpod/master/libgpod-libplist.patch"
     patch -p0 < callout.patch
     patch -p1 < libplist.patch
+
+    # Add itdb_usb.c for SysInfoExtended USB read support
+    bash "$REPO_ROOT/tools/prebuild/patches/apply-sysinfo-usb.sh"
 
     # Point pkg-config at our static deps so configure finds glib, gdk-pixbuf, libplist
     export PKG_CONFIG_PATH="$STATIC_PKG_PATH"
@@ -526,9 +563,9 @@ fi
 log "Verifying static dependencies..."
 MISSING=""
 if [ "$OS" = "Darwin" ]; then
-  REQUIRED="libgpod.a libglib-2.0.a libgobject-2.0.a libgdk_pixbuf-2.0.a"
+  REQUIRED="libgpod.a libglib-2.0.a libgobject-2.0.a libgdk_pixbuf-2.0.a libusb-1.0.a"
 else
-  REQUIRED="libz.a libffi.a libpcre2-8.a libsqlite3.a libglib-2.0.a libgobject-2.0.a libplist-2.0.a libxml2.a libpng16.a libjpeg.a libtiff.a libgdk_pixbuf-2.0.a libgpod.a"
+  REQUIRED="libz.a libffi.a libpcre2-8.a libsqlite3.a libglib-2.0.a libgobject-2.0.a libplist-2.0.a libxml2.a libpng16.a libjpeg.a libtiff.a libgdk_pixbuf-2.0.a libgpod.a libusb-1.0.a"
 fi
 for lib in $REQUIRED; do
   if [ ! -f "$STATIC_DEPS_DIR/lib/$lib" ]; then

--- a/tools/prebuild/get-ldflags.sh
+++ b/tools/prebuild/get-ldflags.sh
@@ -24,7 +24,12 @@ if [ -n "$STATIC_DEPS_DIR" ]; then
 
   if [ "$(uname)" = "Darwin" ]; then
     # macOS: statically link everything — all .a files are built with -fPIC
-    add_static "${STATIC_DEPS_DIR}/lib/libgpod.a" ""
+    # Force-load libgpod to ensure itdb_usb.o is included — it's only
+    # referenced via dlsym at runtime, so the linker would otherwise drop it.
+    if [ -f "${STATIC_DEPS_DIR}/lib/libgpod.a" ]; then
+      LIBS="$LIBS -Wl,-force_load,${STATIC_DEPS_DIR}/lib/libgpod.a"
+    fi
+    add_static "${STATIC_DEPS_DIR}/lib/libusb-1.0.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libgio-2.0.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libgobject-2.0.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libgmodule-2.0.a" ""
@@ -37,7 +42,7 @@ if [ -n "$STATIC_DEPS_DIR" ]; then
     add_static "${STATIC_DEPS_DIR}/lib/libpng16.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libjpeg.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libtiff.a" ""
-    LIBS="$LIBS -liconv -lz -lm -lresolv -framework Foundation -framework CoreFoundation -framework AppKit -framework Carbon"
+    LIBS="$LIBS -liconv -lz -lm -lresolv -framework Foundation -framework CoreFoundation -framework AppKit -framework Carbon -framework IOKit -framework Security"
   else
     # Linux: statically link everything — all .a files built with -fPIC
     # Glib libraries may be in lib/ or lib/{arch}-linux-gnu/ depending on meson
@@ -58,7 +63,12 @@ if [ -n "$STATIC_DEPS_DIR" ]; then
       fi
     }
 
-    add_static "${STATIC_DEPS_DIR}/lib/libgpod.a" ""
+    # Whole-archive libgpod to ensure itdb_usb.o is included — it's only
+    # referenced via dlsym at runtime, so the linker would otherwise drop it.
+    if [ -f "${STATIC_DEPS_DIR}/lib/libgpod.a" ]; then
+      LIBS="$LIBS -Wl,--whole-archive ${STATIC_DEPS_DIR}/lib/libgpod.a -Wl,--no-whole-archive"
+    fi
+    add_static "${STATIC_DEPS_DIR}/lib/libusb-1.0.a" ""
     add_static "${STATIC_DEPS_DIR}/lib/libgdk_pixbuf-2.0.a" ""
     add_static_multiarch "libgio-2.0.a"
     add_static_multiarch "libgobject-2.0.a"

--- a/tools/prebuild/patches/apply-sysinfo-usb.sh
+++ b/tools/prebuild/patches/apply-sysinfo-usb.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Apply SysInfoExtended USB read patch to libgpod source tree.
+#
+# The upstream libgpod 0.8.3 configure.ac already checks for libusb-1.0
+# and sets HAVE_LIBUSB + LIBUSB_CFLAGS/LIBUSB_LIBS. However, the release
+# tarball only uses this in tools/Makefile.am (for the standalone binary).
+#
+# This patch:
+# 1. Copies itdb_usb.c into src/ (the library implementation)
+# 2. Adds HAVE_LIBUSB conditional to src/Makefile.am (compile + link into libgpod.a)
+# 3. Adds public declaration to src/itdb.h
+#
+# Run from within the libgpod-0.8.3 directory.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. Copy itdb_usb.c into src/
+if [ ! -f src/itdb_usb.c ]; then
+  cp "$SCRIPT_DIR/itdb_usb.c" src/itdb_usb.c
+  echo "  Copied itdb_usb.c into src/"
+else
+  echo "  itdb_usb.c already present in src/"
+fi
+
+# 2. Patch src/Makefile.am — add HAVE_LIBUSB block after HAVE_LIBIMOBILEDEVICE
+if ! grep -q 'HAVE_LIBUSB' src/Makefile.am; then
+  # Find the endif that closes HAVE_LIBIMOBILEDEVICE and append after it
+  sed -i.bak '/^if HAVE_LIBIMOBILEDEVICE/,/^endif/{
+    /^endif/a\
+\
+if HAVE_LIBUSB\
+libgpod_la_SOURCES += itdb_usb.c\
+LIBS+=$(LIBUSB_LIBS)\
+libgpod_la_CFLAGS+=$(LIBUSB_CFLAGS)\
+endif
+  }' src/Makefile.am
+  rm -f src/Makefile.am.bak
+  echo "  Patched src/Makefile.am with HAVE_LIBUSB block"
+else
+  echo "  src/Makefile.am already has HAVE_LIBUSB"
+fi
+
+# 3. Patch src/itdb.h — add declaration before G_END_DECLS
+if ! grep -q 'itdb_read_sysinfo_extended_from_usb' src/itdb.h; then
+  sed -i.bak '/^G_END_DECLS/i\
+/* Read SysInfoExtended XML from iPod firmware via USB vendor control transfer.\
+ * Requires libusb. Returns XML string (caller must g_free) or NULL on failure.\
+ * bus_number and device_address identify the USB device. */\
+#ifdef HAVE_LIBUSB\
+gchar *itdb_read_sysinfo_extended_from_usb (guint bus_number, guint device_address);\
+#endif\
+' src/itdb.h
+  rm -f src/itdb.h.bak
+  echo "  Patched src/itdb.h with USB function declaration"
+else
+  echo "  src/itdb.h already has USB function declaration"
+fi

--- a/tools/prebuild/patches/itdb_usb.c
+++ b/tools/prebuild/patches/itdb_usb.c
@@ -1,0 +1,107 @@
+#include <libusb.h>
+#include <glib.h>
+
+static int send_command (libusb_device_handle *handle, const guint value, const guint index, guchar *data, gsize len)
+{
+    return libusb_control_transfer (handle, LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE, 0x40, value, index, data, len, 0);
+}
+
+static libusb_device_handle *open_handle (libusb_context *ctx, const guint bus_number, const guint device_address)
+{
+    libusb_device **list;
+    libusb_device *dev;
+    libusb_device_handle *handle;
+    unsigned int i;
+
+    int success;
+    int device_count;
+
+    device_count = libusb_get_device_list (ctx, &list);
+    if (device_count < 0) {
+        return NULL;
+    }
+
+    dev = NULL;
+    for (i = 0; i < device_count; i++) {
+        if (libusb_get_bus_number (list[i]) != bus_number) {
+            continue;
+        }
+        if (libusb_get_device_address (list[i]) != device_address) {
+            continue;
+        }
+        dev = list[i];
+        break;
+    }
+
+    if (dev == NULL) {
+        libusb_free_device_list (list, 1);
+        return NULL;
+    }
+
+    success = libusb_open (dev, &handle);
+    libusb_free_device_list (list, 1);
+    if (success < 0) {
+        return NULL;
+    }
+
+    return handle;
+}
+
+
+static gchar *get_sysinfo_extended (libusb_device_handle *handle)
+{
+    GString *sysinfo_extended;
+    guchar data[0x1000];
+    unsigned int i;
+
+    sysinfo_extended = g_string_sized_new (0x8000);
+
+    for (i = 0; i < 0xffff; i++) {
+        int bytes_read;
+        bytes_read = send_command (handle, 0x02, i, data, sizeof (data));
+        if (bytes_read < 0) {
+            g_string_free (sysinfo_extended, TRUE);
+            return NULL;
+        }
+        g_string_append_len (sysinfo_extended, (gchar*)data, bytes_read);
+        if (bytes_read != sizeof (data)) {
+            /* assume short reads mean "end of file" */
+            break;
+        }
+    }
+
+    if (sysinfo_extended->len == 0) {
+        /* Nothing could be read from USB */
+        g_string_free(sysinfo_extended, TRUE);
+        return NULL;
+    }
+
+    return g_string_free (sysinfo_extended, FALSE);
+}
+
+gchar *itdb_read_sysinfo_extended_from_usb (guint bus_number, guint device_address)
+{
+    int success;
+    libusb_context *ctx;
+    libusb_device_handle *handle;
+    gchar *sysinfo_extended;
+
+    success = libusb_init (&ctx);
+    if (success < 0) {
+        return NULL;
+
+    }
+
+    handle = open_handle (ctx, bus_number, device_address);
+    if (handle == NULL) {
+        libusb_exit (ctx);
+        return NULL;
+    }
+
+    sysinfo_extended = get_sysinfo_extended (handle);
+
+    libusb_close (handle);
+    libusb_exit (ctx);
+
+    return sysinfo_extended;
+}


### PR DESCRIPTION
## Problem

Modern iPods (post-2006) don't create a populated `SysInfo` file after restore via iTunes. Without it, libgpod treats the device as "generic" — artwork stops working, ALAC support is unknown, and database checksums fail on Classic 6/7G and Nano 3G+. This is the most common first-time podkit user scenario: plug in a freshly restored iPod, and it doesn't work properly.

The root cause: libgpod was designed around a manual workflow where users ran a separate tool (`ipod-read-sysinfo-extended`) before using the library. The identity data has always been available from the device firmware — it was just never integrated into an automated flow.

## Solution

podkit now automatically reads SysInfoExtended from iPod firmware via USB during `device add`. The rich identity data (serial number → exact model with color, capacity, generation) flows through to device identification, capability detection, and checksum generation.

**User experience after this change:**
- `podkit device add` identifies the exact device (e.g., "iPod nano 8GB Black (3rd Generation)") with no manual input
- `podkit doctor` detects missing SysInfoExtended and suggests `--repair sysinfo-extended`
- `podkit sync` works correctly on first run with full capability detection
- Hash72 (Nano 5G) and HashAB (Nano 6G) devices get clear limitation messages

## Technical approach

### Identification chain
```
USB discovery → serial/bus/address → libusb vendor transfer → SysInfoExtended XML
→ serial suffix → model lookup → checksum type → readiness decision
```

### Key decisions

**dlsym for native binding:** The `readSysInfoExtendedFromUsb()` function is resolved at runtime via `dlsym`, not linked statically. This lets the binding load on systems where libgpod lacks the function (system packages, older builds) — it returns null gracefully instead of failing at load time.

**Patching upstream libgpod:** The upstream 0.8.3 tarball has `itdb_usb.c` only in `tools/` (standalone binary). Our CI patch moves it into the library (`src/`) so it's part of `libgpod.a`. The `--whole-archive` / `-force_load` linker flags ensure the symbol survives into the `.node` binary despite only being referenced via dlsym.

**Non-blocking device add:** SysInfoExtended is a bonus, not a gate. USB read failures are logged at verbose level only — older iPods that don't need checksums continue to work.

**Checksum severity in readiness:** Devices requiring hash58+ checksums (Classic 6/7G, Nano 3/4G) **fail** without SysInfoExtended. Pre-checksum devices (Video 5G, Mini, Nano 1-2G) **warn** — they work but lack full capability data.

## Changes

### Phase 1: Foundation
- **USB discovery** — `serialNumber`, `busNumber`, `deviceAddress` on `UsbDiscoveredDevice`; `resolveUsbDeviceFromPath()` on both platforms
- **Unified model registry** — replaces separate lookup tables with single registry; both `0x120x`/`0x126x` USB ID ranges; 190+ serial suffix→model mappings; checksum type classification per generation
- **Native binding** — `readSysInfoExtendedFromUsb()` via N-API with dlsym runtime resolution

### Phase 2: Integration
- **Orchestrator** — `ensureSysInfoExtended()`: check existing → USB read → validate XML → write to device
- **Readiness pipeline** — `checkSysInfo` checks SysInfoExtended first; checksum-aware severity; hash72/hashAB limitation notes
- **Diagnostic check** — `sysinfo-extended` repair via `resolveUsbDeviceFromPath` + orchestrator
- **Device add** — `attemptSysInfoExtended()` after mount, before DB init; enriches model name in summary

### CI & Build
- **Prebuild** — libusb 1.0.27 built from source on all 6 platforms; libgpod patched with `itdb_usb.c`
- **Smoke test** — `readSysInfoExtendedFromUsb(99, 99)` → null (no crash) on all platforms

### Refactoring
- macOS USB tree traversal consolidated (shared `findUsbDeviceNode`)
- `determineLevel()` restructured as declarative `READINESS_RULES` array
- Both platforms now populate full `UsbDeviceInfo` (serial, bus, address)

## Test plan

- [x] 2394 podkit-core unit tests pass
- [x] 33 libgpod-node tests pass (including USB smoke test)
- [x] Full build clean (12 packages)
- [x] Lima VM tests pass (Debian + Alpine)
- [x] Real hardware: 14KB SysInfoExtended XML from iPod Nano 4G
- [x] E2E test: device add attempts SysInfoExtended read (verbose output verified)
- [x] CI prebuild passes on all 6 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)