### PR TITLE
fix(test): stop the heartbeat test racing the scheduler

### DIFF
--- a/backlog/tasks/task-495 - Add-a-CI-backstop-that-actually-runs-tests-on-push.md
+++ b/backlog/tasks/task-495 - Add-a-CI-backstop-that-actually-runs-tests-on-push.md
@@ -4,7 +4,7 @@ title: Add a CI backstop that actually runs tests on push
 status: In Progress
 assignee: []
 created_date: '2026-09-07 23:36'
-updated_date: '2026-09-08 19:11'
+updated_date: '2026-09-08 21:04'
 labels:
   - testing
   - ci
@@ -41,7 +41,7 @@ This is a backstop, not the primary gate — rapid local loops remain the point,
 - [x] #1 A CI job runs unit and integration tests on pull requests
 - [x] #2 A CI job runs the host-binary · local-dir · dir E2E surface
 - [x] #3 A CI job runs the docker-sidecar surface
-- [ ] #4 Turbo caching is configured so the job is not rebuilding everything from scratch each run
+- [x] #4 Turbo caching is configured so the job is not rebuilding everything from scratch each run
 - [x] #5 The docs-only path filter on pr-checks.yml does not cause the test job to be skipped on code-only PRs
 - [x] #6 pr-checks.yml is deleted and the docs-site build is still covered on PRs, via turbo rather than a path filter
 - [x] #7 //#lint hashes shell scripts and excludes node_modules/dist/build, closing the cached-green shellcheck hole
@@ -123,4 +123,34 @@ AC #4 and #8 deliberately left unchecked:
 Runs 1, 2 and 4 were latent bugs no machine in the project could have found, which is precisely the ADR-028 §6 argument.
 
 **Unresolved, raised with the owner:** `@types/bun` is `"latest"` in 21 manifests. A dist-tag is re-resolved against the registry on every install, so `--frozen-lockfile` will break again on the next upstream publish — on somebody else's unrelated PR. Options are pin-to-range, drop `--frozen-lockfile` on CI, or refresh reactively. Not decided.
+
+**Merged, and AC #4 proven on main (2026-09-08).** PR #70 merged by rebase; `ci.yml` is on `main`.
+
+Cross-run turbo caching verified with real evidence rather than assumed. Main run 34270045074 logged:
+
+```
+key:          turbo-Linux-X64-34270045074
+restore-keys: turbo-Linux-X64-
+Cache hit for restore-key: turbo-Linux-X64-34270021092
+```
+
+The deliberate-primary-miss design works: the `github.run_id` key never hits, and `restore-keys` returns the newest entry in scope. The saved cache is 138 MB on `refs/heads/main`.
+
+It also vindicates the `if: always()` on the save step — run 34270021092 **failed** at `test:e2e` and still saved, which is the only reason the next run had anything to restore. A success-only save would have left the cache empty after a red run, exactly when the next run most needs it.
+
+Effect, warm vs cold on main:
+
+| step | cold (34270021092) | warm (34270045074) |
+|---|---|---|
+| Lint, typecheck, build | — | **1s** |
+| Unit + integration | — | **1s** |
+| E2E local-dir | — | 201s |
+| E2E docker-sidecar | not reached | 59s |
+| **job total** | 444s | **339s** |
+
+Build, unit and integration replay in a second each. The e2e steps still ran because run 1 failed at `test:e2e` and so never wrote a cache entry for either e2e task — not a caching defect.
+
+**Still open: AC #8**, the concurrency tuning pass. Deliberately not attempted yet: task-501 (FFmpeg exit 254, ~33% of runs that reach `test:e2e`) has to be understood first, because raising `TEST_CONCURRENCY` while an unexplained concurrency-shaped flake is live would confound both. Tune after 501.
+
+**Not merged with #70:** the heartbeat flake fix and the task-496/501 updates missed the merge by one commit; they are PR #71.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-496 - Deduplicate-the-docs-build-job-across-workflows-once-CI-lands.md
+++ b/backlog/tasks/task-496 - Deduplicate-the-docs-build-job-across-workflows-once-CI-lands.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-496
-title: Deduplicate the docs-build job across workflows once CI lands
+title: Audit and consolidate the workflows the CI backstop now supersedes
 status: To Do
 assignee: []
 created_date: '2026-09-08 18:03'
+updated_date: '2026-09-08 19:40'
 labels:
   - ci
   - testing
@@ -19,27 +20,34 @@ ordinal: 275000
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Deliberately deferred out of task-495 to keep that PR off the release path. **Do not lose this** — task-495 deletes `pr-checks.yml`, which leaves the duplication half-cleaned.
+Now that `ci.yml` exists (task-495), several workflows overlap it or duplicate each other. Deliberately deferred out of that PR to keep it off the release path — **do not lose this**: task-495 already deleted `pr-checks.yml`, which leaves the duplication half-cleaned.
 
-The bun+docs preamble is duplicated **verbatim, explanatory comment included**, in three places:
+Work through the eight workflows and decide, for each, whether it is superseded, overlapping, or still load-bearing.
 
-- `.github/workflows/pr-checks.yml` — deleted by task-495
-- `.github/workflows/verify-release.yml` (the `docs` job)
-- `.github/workflows/deploy-docs.yml`
+## Known overlaps
 
-Each is: checkout → `oven-sh/setup-bun@v2` → `bun install --frozen-lockfile --ignore-scripts` → `bunx turbo run build --filter=@podkit/devices-ipod` → `cd packages/docs-site && bun run build`. The 5-line comment explaining why only `@podkit/devices-ipod` is built appears word-for-word in `verify-release.yml:91-94` and `deploy-docs.yml:33-37`.
+**1. `verify-release.yml`'s `docs` job is redundant.** Version Packages PRs fire `pull_request`, so `ci.yml` covers them, and `@podkit/docs-site#build` is already in turbo's graph (docs-site has no test script, but turbo materialises the task node and runs its `build` as a dependency). Removing it also means updating `release-ci-passed`'s `needs` and its result checks — that coupling to the release path is exactly why it was split out.
 
-**The `verify-release.yml` docs job is redundant after task-495.** Version Packages PRs fire `pull_request`, so the new `ci.yml` covers them, and `@podkit/docs-site#build` is already in turbo's graph (it has no test scripts, but turbo materialises the task node and runs `build` as a dependency of the phantom `test:unit`/`test:integration`). Removing it also requires updating `release-ci-passed`'s `needs` and its result checks — that coupling to the release path is why this was split out.
+**2. The bun+docs preamble is triplicated verbatim, comment included** — it was in `pr-checks.yml` (now deleted), `verify-release.yml`'s `docs` job, and `deploy-docs.yml`. Each is: checkout → `oven-sh/setup-bun@v2` → `bun install --frozen-lockfile --ignore-scripts` → `bunx turbo run build --filter=@podkit/devices-ipod` → `cd packages/docs-site && bun run build`. The 5-line comment explaining why only `@podkit/devices-ipod` is built appears word-for-word in `verify-release.yml:91-94` and `deploy-docs.yml:33-37`. `deploy-docs.yml` is triggered by `push: docs-live` and has no equivalent coverage, so it must keep building the site itself.
 
-`deploy-docs.yml` is triggered by `push: docs-live` and has no equivalent coverage, so it must keep doing its own build.
+**3. `.github/actions/setup-podkit` was considered for task-495 and rejected** — after that work there was only one full caller, so it would have been indirection with no reuse. Re-decide here: the calculus changes if `usb-synth` on CI (deferred by ADR-028 §6) or e2e sharding creates a second caller.
 
-**Also revisit here:** a `.github/actions/setup-podkit` composite action was considered for task-495 and rejected — after that work there is only one full caller, so it would be indirection with no reuse. Reconsider when a second job genuinely needs the native toolchain (most likely `usb-synth` on CI, deferred by ADR-028 §6, or sharding `test:e2e`).
+## Also worth deciding here
+
+- **Required checks.** The `Release checks` ruleset on the default branch currently requires exactly one context, `Release CI Status`. `CI Status` should join it once the backstop has proven itself — decide whether both belong, or whether `Release CI Status` is now redundant for non-release PRs given it self-gates on the PR title.
+- **`build-platform.yml` is 820 lines** with 6+ copies of the libc verification gates (`readelf -d` NEEDED, `readelf -l` interpreter, `ldd`/`otool -L`) and four divergent `actions/cache` key families. Not superseded by `ci.yml`, but it is the largest duplication in the repo and the natural next target.
+- **Hygiene the audit will surface:** no action is SHA-pinned, there is no `dependabot.yml`, and every workflow but `ci.yml` uses `bun-version: latest` while `mise.toml` pins `1.3.13`. Decide whether to fix here or split out.
+
+Scope this pragmatically — the goal is that no workflow runs work `ci.yml` already does, not a rewrite of the release pipeline.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The docs job is removed from verify-release.yml and release-ci-passed's needs/result checks are updated to match
-- [ ] #2 A Version Packages PR is verified to still get a docs build via the new CI workflow
-- [ ] #3 deploy-docs.yml still builds the docs site on push to docs-live
-- [ ] #4 The decision on whether a setup-podkit composite action is now warranted is recorded either way
+- [ ] #1 Every workflow is classified as superseded by ci.yml, overlapping, or still load-bearing, with the reasoning recorded
+- [ ] #2 The docs job is removed from verify-release.yml and release-ci-passed's needs/result checks are updated to match
+- [ ] #3 A Version Packages PR is verified to still get a docs build via ci.yml
+- [ ] #4 deploy-docs.yml still builds the docs site on push to docs-live
+- [ ] #5 No workflow duplicates work ci.yml already performs
+- [ ] #6 The decision on whether a setup-podkit composite action is now warranted is recorded either way
+- [ ] #7 A decision is recorded on which checks the Release checks ruleset should require now that CI Status exists
 <!-- AC:END -->

--- a/backlog/tasks/task-501 - art-matrix-resize-flakes-on-CI-with-FFmpeg-exit-254-across-every-hires-format.md
+++ b/backlog/tasks/task-501 - art-matrix-resize-flakes-on-CI-with-FFmpeg-exit-254-across-every-hires-format.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-501
-title: art-matrix-resize flakes on CI with FFmpeg exit 254 across every hires format
+title: art-matrix suites flake with FFmpeg exit 254 across every hires format
 status: To Do
 assignee: []
 created_date: '2026-09-08 19:35'
+updated_date: '2026-09-08 21:02'
 labels:
   - testing
   - ci
@@ -11,7 +12,7 @@ dependencies: []
 references:
   - test-packages/e2e-tests/src/features/art-matrix-resize.test.ts
   - test-packages/e2e-tests/src/matrix/artwork-rules.ts
-priority: medium
+priority: high
 type: bug
 ordinal: 280000
 ---
@@ -67,3 +68,29 @@ Since the inputs were present, suspicion falls on the **output** path — a temp
 - [ ] #3 The race is fixed, or the test made robust to it, without weakening what it asserts about resize behaviour
 - [ ] #4 The fix is validated across enough consecutive CI runs to be meaningfully better than 1-in-4
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Rescoped and re-prioritised (2026-09-08): this is not resize-specific.** The first CI run on `main` after task-495 merged (run 34270021092) failed with the identical signature — 14 × `FFmpeg exited with code 254`, `category: "transcode"`, every hires format — but in **`art-matrix-transfer.test.ts`**, not `art-matrix-resize.test.ts`.
+
+So the original framing was wrong in a way that matters: it is not one test racing its own temp dir, it is something in the shared art-matrix path. Whatever the cause, it can hit any file in that family, which also rules out the "only this file consumes the hires set" reasoning in the description above — that was true of resize but is not the boundary of the bug.
+
+**Revised rate: 2 failures in 6 CI runs that reached `test:e2e`.**
+
+| run | reached e2e | result |
+|---|---|---|
+| 34264912360 | yes | pass |
+| 34266500844 | yes | pass |
+| 34268183681 attempt 1 | yes | **fail — art-matrix-resize** |
+| 34268183681 attempt 2 | yes | pass |
+| 34269928947 | no (died earlier on the heartbeat flake) | — |
+| 34270021092 (main) | yes | **fail — art-matrix-transfer** |
+| 34270045074 (main) | yes | pass |
+
+~33% is not a rare flake, and it is now failing on `main`, not just on a PR branch. Raised to High: at this rate the backstop cannot be made a required check, which defeats the point of task-495.
+
+Still never reproduced on the Linux dev host (`bun run test:e2e` 37/37) or on macOS, so it is specific to the CI runner — 4 vCPU, `TEST_CONCURRENCY=2`, rootful Docker, mise-pinned conda FFmpeg 9.0.1.
+
+A promising next step is to stop inferring from exit codes and capture the actual FFmpeg stderr: the sync layer reports only `FFmpeg exited with code 254`, and the argv-shim technique used while diagnosing task-499 (a logging wrapper ahead of ffmpeg on `PATH`) would show both the command and its diagnostics.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-501 - art-matrix-resize-flakes-on-CI-with-FFmpeg-exit-254-across-every-hires-format.md
+++ b/backlog/tasks/task-501 - art-matrix-resize-flakes-on-CI-with-FFmpeg-exit-254-across-every-hires-format.md
@@ -4,7 +4,7 @@ title: art-matrix suites flake with FFmpeg exit 254 across every hires format
 status: To Do
 assignee: []
 created_date: '2026-09-08 19:35'
-updated_date: '2026-09-08 21:02'
+updated_date: '2026-09-08 21:12'
 labels:
   - testing
   - ci
@@ -93,4 +93,16 @@ So the original framing was wrong in a way that matters: it is not one test raci
 Still never reproduced on the Linux dev host (`bun run test:e2e` 37/37) or on macOS, so it is specific to the CI runner — 4 vCPU, `TEST_CONCURRENCY=2`, rootful Docker, mise-pinned conda FFmpeg 9.0.1.
 
 A promising next step is to stop inferring from exit codes and capture the actual FFmpeg stderr: the sync layer reports only `FFmpeg exited with code 254`, and the argv-shim technique used while diagnosing task-499 (a logging wrapper ahead of ffmpeg on `PATH`) would show both the command and its diagnostics.
+
+**Leading hypothesis from the repo owner: `TEST_CONCURRENCY` is implicated.** Worth treating as the first thing to test rather than one item on a list.
+
+What makes it plausible:
+
+- The flake has **only ever been seen on CI**, which is the only environment running `TEST_CONCURRENCY=2`. The Linux dev host and macOS both run the default of 4 and have never reproduced it — so the correlation, such as it is, points at the *lower* setting, not the higher one. That is counter-intuitive enough to be worth understanding before assuming "less parallelism is safer".
+- Both observed failures were in the **art-matrix family**, whose files are the longest-running in the suite. Which files end up running *concurrently* is a function of the concurrency setting and of file ordering, so a different setting reshuffles which pairs overlap. A pairwise interaction would look exactly like this: stable for several runs, then a specific pairing lands and six transcodes fail at once.
+- All six formats failing simultaneously, `bytesTransferred: 0`, `duration: 7.56` — consistent with a shared resource being unavailable for the whole pass rather than per-track bad luck.
+
+Concrete way to test it: run `test:e2e` on CI at `TEST_CONCURRENCY` 1, 2 and 4 several times each via `workflow_dispatch`, and record failure rate per setting. If 1 is clean, that is strong evidence for a cross-file interaction and narrows the search to whatever the art-matrix files share — a temp path, the fixture root, or the artwork cache.
+
+This also blocks task-495 AC #8: the concurrency tuning pass must not be attempted until this is understood, or the two changes confound each other and neither result means anything.
 <!-- SECTION:NOTES:END -->

--- a/test-packages/lima/src/progress.test.ts
+++ b/test-packages/lima/src/progress.test.ts
@@ -38,14 +38,24 @@ describe('startHeartbeat', () => {
       report: (line) => lines.push(line),
       intervalMs: 10,
     });
-    await Bun.sleep(35);
+    // Wait for two ticks rather than sleeping a fixed span and hoping. A fixed
+    // sleep races the scheduler: on a loaded CI runner timer callbacks coalesce,
+    // so `intervalMs: 10` does not reliably fire twice inside 35ms of wall clock
+    // and the test fails for reasons that have nothing to do with the heartbeat.
+    // The ceiling still fails a genuinely broken interval, just not a slow host.
+    const deadline = Date.now() + 5_000;
+    while (lines.length < 2 && Date.now() < deadline) {
+      await Bun.sleep(5);
+    }
     beat.stop();
     const seen = lines.length;
     expect(seen).toBeGreaterThanOrEqual(2);
     expect(lines[0]).toMatch(/^still waiting on `limactl stop podkit-device` \(\d+s elapsed\)$/);
 
-    // stop() really stops: no further lines after the handle is released.
-    await Bun.sleep(30);
+    // stop() really stops: no further lines after the handle is released. Sleep
+    // well past the interval so a *failure* to stop is actually observed — at
+    // 3x the interval a slow tick could otherwise read as a clean stop.
+    await Bun.sleep(200);
     expect(lines).toHaveLength(seen);
   });
 


### PR DESCRIPTION
Picks up the tail of #70, which merged one commit short.

## The fix

`@podkit/lima#test:unit` flaked on CI — and then again on the **first `main` run** after #70 merged:

```
startHeartbeat > reports elapsed time against the label at the configured interval
expect(received).toBeGreaterThanOrEqual(expected)
```

It slept a fixed 35ms against `intervalMs: 10` and expected two ticks. On a loaded 4-vCPU runner timer callbacks coalesce, so two ticks aren't guaranteed in that window and the test fails for reasons unrelated to the heartbeat.

Now it *waits for* two ticks with a 5s ceiling. A genuinely broken interval still fails; a slow host doesn't. The very next test in the same file already had the right pattern — "Force one tick deterministically rather than racing the interval" — so this was a known technique simply not applied here.

I also lengthened the sleep proving `stop()` really stops, 30ms → 200ms. At 3× the interval a merely-slow tick could read as a clean stop, so that assertion was weakest in exactly the conditions that trip the first one.

Swept the repo: only two non-e2e test files use `Bun.sleep`, so this isn't a pattern.

## Backlog

- **task-496** widened from "deduplicate the docs-build job" to a full audit of which workflows `ci.yml` supersedes — deleting `pr-checks.yml` left that consolidation half-done, and the audit should also settle which checks the `Release checks` ruleset requires now that `CI Status` exists.
- **task-501** rescoped and raised to **High**. The `FFmpeg exit 254` flake is *not* specific to `art-matrix-resize`: main run `34270021092` hit the identical signature — 14 errors, every hires format — in `art-matrix-transfer`. That's **2 failures in 6 CI runs that reached `test:e2e`**. At ~33% the backstop can't become a required check, which defeats the point of #70.

task-501 is now the main thing standing between this gate and being trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HEbPxhp36S8jdp11JrjBd